### PR TITLE
Initial checkin of PullRequest builder code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,3 @@
-# Eclipse OpenJ9 website
-
-
-This repository contains the HTML source files for the [Eclipse OpenJ9 website](http://www.eclipse.org/openj9).
-
-If you would like to contribute to the content on this website, please read
-these [Contributions guidelines](https://github.com/eclipse/openj9/blob/master/CONTRIBUTING.md).
-
-Changes made to this repository are automatically promoted.
-
-## Previewing pull requests (whitelisted users only)
-
-Pull requests must be previewed before merging by using the following Jenkins-ci job: https://ci.eclipse.org/openj9/view/Pull%20Requests/job/PullRequest-Website-test_on_staging_site/
-
-To run the job, add the following trigger comment into a pull request: `Jenkins website stage`
-
-Staging site: http://staging.eclipse.org/openj9
-
-
-## OpenJ9 license information
-
-Copyright (c) 2017 IBM Corp. and others
-
-This program and the accompanying materials are made available under
- the terms of the Eclipse Public License 2.0 which accompanies this
- distribution and is available at http://eclipse.org/legal/epl-2.0
- or the Apache License, Version 2.0 which accompanies this distribution and
- is available at https://www.apache.org/licenses/LICENSE-2.0. 
-
-This Source Code may also be made available under the following
-Secondary Licenses when the conditions for such availability set
-forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-General Public License, version 2 with the GNU Classpath
-Exception [1] and GNU General Public License, version 2
-with the OpenJDK Assembly Exception [2]. 
-
-[1] https://www.gnu.org/software/classpath/license.html  
-[2] http://openjdk.java.net/legal/assembly-exception.html 
-
-SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
-
 <!--
 Copyright (c) 2017, 2017 IBM Corp. and others
 
@@ -59,3 +18,52 @@ OpenJDK Assembly Exception [2].
 [2] http://openjdk.java.net/legal/assembly-exception.html
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+-->
+# Eclipse OpenJ9 website
+
+
+This repository contains the HTML source files for the [Eclipse OpenJ9 website](http://www.eclipse.org/openj9).
+
+If you would like to contribute to the content on this website, please read
+these [Contributions guidelines](https://github.com/eclipse/openj9/blob/master/CONTRIBUTING.md).
+
+Changes merged into this repository's master branch are automatically synced into the Eclipse git website repo's master branch. The two master branches should always have the same content, though possibly up to 5 minutes delayed due to sync timing.
+
+## Previewing pull requests (whitelisted users only)
+
+Pull requests must be previewed before merging by triggering the [Jenkins-ci job](https://ci.eclipse.org/openj9/job/PullRequest-Website-test_on_staging_site/)  
+To run the job, add the following trigger comment into a pull request:  
+```
+Jenkins website stage
+```  
+Staging site: http://staging.eclipse.org/openj9
+
+#### Please Note
+The staging website is based on the staging branch of the Eclipse repo.  
+Since there is only one staging branch, whichever PR job ran last, will be the current one staged to the staging website.  
+You can view the [build history](https://ci.eclipse.org/openj9/job/PullRequest-Website-test_on_staging_site/) on the build page (left hand column) to see which PR ran last. Each run is annotated with the link to the PR as well as the PR title.  
+Also note that it can take a few minutes for the contents of the staging website to refresh.
+
+## OpenJ9 license information
+
+```
+Copyright (c) 2017 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+ the terms of the Eclipse Public License 2.0 which accompanies this
+ distribution and is available at http://eclipse.org/legal/epl-2.0
+ or the Apache License, Version 2.0 which accompanies this distribution and
+ is available at https://www.apache.org/licenses/LICENSE-2.0. 
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2
+with the OpenJDK Assembly Exception [2]. 
+
+[1] https://www.gnu.org/software/classpath/license.html  
+[2] http://openjdk.java.net/legal/assembly-exception.html 
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+```

--- a/jenkinsPullRequests
+++ b/jenkinsPullRequests
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+pipeline {
+    agent {label 'master'}
+
+    environment {
+        GITHUB_REPO = 'https://github.com/eclipse/openj9-website.git'
+        ECLIPSE_REPO = '/gitroot/www.eclipse.org/openj9.git'
+        BRANCH = 'staging'
+    }
+
+    stages {
+        stage('Clone') {
+            steps {
+                timestamps {
+                    dir('github_repo') {
+                        git url: GITHUB_REPO
+                        sh 'git fetch --tags --progress origin +refs/pull/*:refs/remotes/origin/pr/*'
+                        sh "git checkout ${sha1}"
+                    }
+                    dir('staging_repo') {
+                        git branch: BRANCH, url: ECLIPSE_REPO
+                    }
+                }
+            }
+        }
+
+        stage('Stage') {
+            steps {
+                timestamps {
+                    // This process is slightly convoluted as we don't have rights to force push the staging brach.
+                    // Instead we generate a new commit based on the diff of the Staging branch vs PR content.
+                    // This makes the history of the staging branch very different from master and it will never
+                    // be merged back into master.
+                    // The staging branch is more of a 'preview' branch rather than a stage->deploy setup.
+                    // - Copy on disk Github repo (PR content) over Eclipse repo.
+                    // - Stage all changes, generate commit & push to staging branch
+                    dir('staging_repo') {
+                        sh 'rm -rf * .gitignore'
+                        sh "cp -r ${WORKSPACE}/github_repo/* ."
+                        sh "cp -r ${WORKSPACE}/github_repo/.gitignore ."
+                        sh 'git status'
+                        sh 'git add -A'
+                        sh 'git status'
+                        sh 'git commit -m "Generated from commit: ${sha1}"'
+                        sh 'git status'
+                        sh "git push origin ${BRANCH}"
+                        sh "git diff origin/${BRANCH}..origin/master"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Clone Github repo
- Checkout merge commit of PullRequest
- Clone Eclipse repo, staging branch
- Copy content on disk from Github to Eclipse
- Create commit based on diff
- Push to staging branch
- Staging website http://staging.eclipse.org/openj9/

Part of Issue #12

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>