### PR TITLE
Simplify command string to build docker image

### DIFF
--- a/oj9_build.html
+++ b/oj9_build.html
@@ -89,7 +89,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
           </ul>
           <p>Save the Dockerfile to your current directory and specify these commands to build and run the Docker image:
           </p>
-<pre><code>docker build -t openj9 -f Dockerfile .</code>
+<pre><code>docker build -t openj9 .</code>
 <code>docker run -it openj9</code></pre>
         <p>Depending on your <a href="https://docs.docker.com/engine/reference/commandline/cli/#description" target="_blank">Docker system configuration</a>, you might need to prefix these commands with <code>sudo</code>.
           </p>


### PR DESCRIPTION
Remove the `-f Dockerfile` from the string as
docker looks for that filename by default.

issue #41

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>