### PR TITLE
Add slackin capability for automating slack invite

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,12 +176,14 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
       <div class="f-section-item">
         <div class="f-content-container">
           <p><span class="first-word">Ask questions</span>
-          If you get stuck trying to do something, our developers monitor and participate in <code class="stack">#OpenJ9</code> questions on Stack Overflow. For more general questions about OpenJ9 and how it fits into the OpenJDK ecosystem, we've created an FAQ, which will grow over time.
+          If you get stuck trying to do something, <a href="oj9_joinslack.html">join our Slack channel</a> where you can get some help from the community. Our developers also monitor <code class="stack">#OpenJ9</code> questions on Stack Overflow. For very general questions about OpenJ9 and how it fits into the OpenJDK ecosystem, we've created an <a href="oj9_faq.html">FAQ</a>.
           </p>
         </div>
         <div class="f-button-container">
-          <a class="button external-button left-half" href="oj9_faq.html">FAQ</a>
-          <a class="button external-button right-half" href="https://stackoverflow.com/search?q=%23OpenJ9" target="_blank">Stack Overflow<i class="fa fa-stack-overflow" aria-hidden="true"></i></a>
+          <a class="button external-button left-half" href="oj9_joinslack.html">Join</a>
+          <a class="button external-button right-half" href="https://openj9.slack.com/" target="_blank">Slack channel<i class="fa fa-slack" aria-hidden="true"></i></a>
+		  <br>
+		  <a class="button external-button" href="https://stackoverflow.com/search?q=%23OpenJ9" target="_blank">Stack Overflow<i class="fa fa-stack-overflow" aria-hidden="true"></i></a>
         </div>
       </div>
 
@@ -210,7 +212,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
      <div class="f-section-item">
         <div class="f-content-container">
           <p><span class="first-word">Make suggestions</span>
-          If you are using OpenJ9 within a Java runtime environment and you have ideas for improvements, share them. We'd love to hear from you.
+          If you are using OpenJ9 within a Java runtime environment and you have ideas for improvements, share them in our <a href="href="https://openj9.slack.com">slack channel</a> (Join <a href="oj9_joinslack.html">here</a>). We'd love to hear from you.
           </p>
         </div>
       </div>
@@ -218,12 +220,20 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
       <div class="f-section-item">
         <div class="f-content-container">
           <p><span class="first-word">Contribute</span>
-          If you are interested in contributing to the development of this open-source project, check out the contribution guide in our GitHub repository.
+          If you are interested in contributing to the development of this open-source project, check out the <a href="https://github.com/eclipse/openj9/blob/master/CONTRIBUTING.md">contribution guide</a> in our GitHub repository.
+		  You can also find out more about the project, including release plans, at our <a href="https://projects.eclipse.org/projects/technology.openj9">Eclipse Foundation project page</a>.
           </p>
         </div>
       </div>
 
-      <div class="f-section-item">
+	  <div class="f-section-item">
+        <div class="f-button-container">
+          <a class="button external-button" href="https://openj9.slack.com" target="_blank">Slack channel 
+          <i class="fa fa-slack" aria-hidden="true"></i>
+          </a>
+	  </div>
+		
+		
         <div class="f-button-container">
           <a class="button external-button" href="https://dev.eclipse.org/mailman/listinfo/openj9-dev" target="_blank">Eclipse mailing list 
           <i class="fa fa-envelope-o" aria-hidden="true"></i>
@@ -246,6 +256,11 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
     <div class="social-icon">
       <a href="https://github.com/eclipse/openj9" target="_blank" title="Github">
         <i class="fa fa-github" aria-hidden="true" style="font-size: 2.3rem;"></i>
+      </a>
+    </div>
+	<div class="social-icon">
+      <a href="https://openj9.slack.com/" target="_blank" title="Slack">
+      	<i class="fa fa-slack" aria-hidden="true" style="font-size:2rem;"></i>
       </a>
     </div>
     <div class="social-icon">

--- a/oj9_build.html
+++ b/oj9_build.html
@@ -327,6 +327,11 @@ OpenJDK  - 8593b2f based on )
         <i class="fa fa-github" aria-hidden="true" style="font-size: 2.3rem;"></i>
       </a>
     </div>
+	<div class="social-icon">
+      <a href="https://openj9.slack.com/" target="_blank" title="Slack">
+      	<i class="fa fa-slack" aria-hidden="true" style="font-size:2rem;"></i>
+      </a>
+    </div>
     <div class="social-icon">
       <a href="https://stackoverflow.com/search?q=%23OpenJ9" target="_blank" title="Stack Overflow">
         <i class="fa fa-stack-overflow" aria-hidden="true" style="font-size: 2rem;"></i>

--- a/oj9_faq.html
+++ b/oj9_faq.html
@@ -53,7 +53,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
       <h1>Frequently asked questions</h1>
 
       <div class="f-section-item">
-        <span class="intro-text">This FAQ answers common questions about Eclipse OpenJ9 and how it fits into the OpenJDK ecosystem. If you can't find the answer you're looking for, post a query on our <a href="https://github.com/eclipse/openj9/issues" target="_blank"><span class="no-wrap">GitHub issues list<i class="fa fa-github-alt" aria-hidden="true"></i></span></a></span>
+        <span class="intro-text">This FAQ answers common questions about Eclipse OpenJ9 and how it fits into the OpenJDK ecosystem. If you can't find the answer you're looking for, ask a question in our <a href="openj9.slack.com">Slack community</a>, which you can join <a href="oj9_joinslack.html">here</a>.</span>
       </div>
 
       <div class="section-item-faq">
@@ -145,9 +145,14 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
   </main>
 
   <footer>
-    <div class="social-icon">
+	<div class="social-icon">
       <a href="https://github.com/eclipse/openj9" target="_blank" title="Github">
         <i class="fa fa-github" aria-hidden="true" style="font-size: 2.3rem;"></i>
+      </a>
+    </div>
+    <div class="social-icon">
+      <a href="https://openj9.slack.com/" target="_blank" title="Slack">
+      	<i class="fa fa-slack" aria-hidden="true" style="font-size:2rem;"></i>
       </a>
     </div>
     <div class="social-icon">

--- a/oj9_joinslack.html
+++ b/oj9_joinslack.html
@@ -1,3 +1,4 @@
+  <script type="text/javascript" src="./js/oj9_common.js"></script>
 <!DOCTYPE html>
 <!--
 Copyright (c) 2017 IBM Corp. and others
@@ -16,7 +17,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>OpenJ9 - What's new?</title>
+  <title>OpenJ9 - Join slack</title>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.min.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.css">
@@ -38,7 +39,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
     <div class="title">
       <a href="index.html">
         <!--<img class="title_icon" src="./assets/openj9_6a.png" alt="Eclipse OpenJ9">-->
-        <img class="title_icon" src="./assets/openj9_6b.png" alt="Eclipse OpenJ9">
+    	  <img class="title_icon" src="./assets/openj9_6b.png" alt="Eclipse OpenJ9">
       </a>
     </div>  
     <div class="egg">
@@ -48,82 +49,34 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
   <main>
 
-	<div id="whatsnew" class="section-content">
-      <h1>What's new?</h1>
+    <div id="joinslack" class="section-content">
+      <h1>Join our Slack community channel</h1>
+
       <div class="f-section-item">
-        <span class="intro-text">Covering anything from project news, events, milestones, and of course... new and cool stuff!</span>
+        <span class="intro-text">To receive an invitation, enter your email address</span>
       </div>
+
 	  <div class="f-section-item">
-        </i><span class="intro-text1" id="slack_ga">Join us on slack</span>
-		</div>
-
-      <div class="f-section-item">
-	    <div class="f-content-container">
-		<p>5th December 2017</p>
-		<p>We're pleased to announce the introduction of a new slack channel, which we hope will become a popular
-		medium for collaborating with the OpenJ9 project team in addition to our Eclipse mailing list. Whether 
-		you have questions to ask or experiences to	share, we'd love to hear from you.</p>  
-		<p>Join the channel by requesting an invitation <a href="oj9_joinslack.html">here</a>.</p>
-		</br>
-		</br>
-		</div>
-	  </div>
-		
-	  <div class="f-section-item">
-        </i><span class="intro-text1" id="openjdk8_ga">Eclipse OpenJ9 for Java 8!</span>
-		</div>
-
-      <div class="f-section-item">
-	    <div class="f-content-container">
-		<p>22nd November 2017</p>
-		  <p>Over the last couple of months, we've been talking about 
-		  OpenJ9 with pretty much everyone who'd listen to us. People have told us that OpenJ9 for Java 9 is a great 
-		  achievement, but many users and developers aren't ready to step up to Java 9 just yet. The most popular 
-		  request we've heard is to combine Eclipse OpenJ9 with a Java 8 JDK so that it can be used in day-to-day 
-		  development and production environments.</p>
-		  <p>We heard that feedback loud and clear, and the Eclipse OpenJ9 community has been working hard to make it a reality!</p>
-		  <p>The OpenJ9 project is proud to announce that you can now build OpenJDK8 with Eclipse OpenJ9. Downloadable binaries are 
-		  already available at the AdoptOpenJDK project:</p>
-		  <br>
-		  <a class="button external-button" style="width:17em; margin-top:1rem;" href="https://adoptopenjdk.net/releases.html?variant=openjdk8-openj9">Grab one here <i class="fa fa-download" aria-hidden="true"></i></a>
-		  <br>
-		  <br>
-		  <p>If you want to build OpenJDK8 with OpenJ9 yourself, you can follow the instructions on our <a href="oj9_build.html">build page</a>. 
-		  Right now, you can build it for Linux on x86-64, ppc64le, s390x, and AIX. More platforms to follow!</p>
-		  <p>Did we already tell you that the Eclipse OpenJ9 project uses a single code stream to implement the JVM across all 
-		  supported Java releases, from Java 8 to Java 9 and beyond? That means users should get the same 
-		  excellent performance, features, and new processor support from OpenJ9 no matter which Java level you're 
-		  using to run your applications.</p>
-		  <p>Interested in what performance you can expect for OpenJDK8 with OpenJ9? The data is not on our website 
-		  at the moment, but for applications we've tried, OpenJDK8 with OpenJ9 performs the same or better than 
-		  OpenJDK9 with OpenJ9. If you haven't seen the impressive results for OpenJDK9 yet, pop over to our <a href="oj9_performance.html">performance page</a>.</p>
-		  <p>We're really excited to bring you Java 8 support, and we hope you'll take it for a test drive. 
-		  We think it will be a great experience for you. Good or bad, let us know how it goes! 
-		  You can connect with us via <a href="https://github.com/eclipse/openj9/issues">GitHub issues</a> or 
-		  on <a href="https://stackoverflow.com/search?q=%23OpenJ9">stackoverflow</a> using the <strong>#openj9</strong> tag. 
-		  We look forward to hearing from you!</p>
-		  <br>
-		  <p><strong>The OpenJ9 project leads:</strong></p>
-		  <p><i>Mark, Dan, Peter, and Jonathan</i></p>
-	     		  
-		  
-
-          
+		<div class="f-content-container">
+            <iframe src="https://slackin-ozuyyvpmac.now.sh/" height="450"
+			frameborder="0" scrolling="no" id="iframe"> ...
+			</iframe>
         </div>
-	</div>
+	  </div>
 
+      
 
-    </div> <!-- end: whatsnew -->
+    </div> <!-- end: build -->
 
   </main>
 
   <footer>
-    <div class="social-icon">
+	<div class="social-icon">
       <a href="https://github.com/eclipse/openj9" target="_blank" title="Github">
         <i class="fa fa-github" aria-hidden="true" style="font-size: 2.3rem;"></i>
       </a>
     </div>
-	<div class="social-icon">
+    <div class="social-icon">
       <a href="https://openj9.slack.com/" target="_blank" title="Slack">
       	<i class="fa fa-slack" aria-hidden="true" style="font-size:2rem;"></i>
       </a>

--- a/oj9_performance.html
+++ b/oj9_performance.html
@@ -284,6 +284,11 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
         <i class="fa fa-github" aria-hidden="true" style="font-size: 2.3rem;"></i>
       </a>
     </div>
+	<div class="social-icon">
+      <a href="https://openj9.slack.com/" target="_blank" title="Slack">
+      	<i class="fa fa-slack" aria-hidden="true" style="font-size:2rem;"></i>
+      </a>
+    </div>
     <div class="social-icon">
       <a href="https://stackoverflow.com/search?q=%23OpenJ9" target="_blank" title="Stack Overflow">
         <i class="fa fa-stack-overflow" aria-hidden="true" style="font-size: 2rem;"></i>

--- a/oj9_resources.html
+++ b/oj9_resources.html
@@ -130,6 +130,11 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
         <i class="fa fa-github" aria-hidden="true" style="font-size: 2.3rem;"></i>
       </a>
     </div>
+	<div class="social-icon">
+      <a href="https://openj9.slack.com/" target="_blank" title="Slack">
+      	<i class="fa fa-slack" aria-hidden="true" style="font-size:2rem;"></i>
+      </a>
+    </div>
     <div class="social-icon">
       <a href="https://stackoverflow.com/search?q=%23OpenJ9" target="_blank" title="Stack Overflow">
         <i class="fa fa-stack-overflow" aria-hidden="true" style="font-size: 2rem;"></i>


### PR DESCRIPTION
Modifications to the index page to introduce our
slack channel, plus a button to "join". The
join button takes the user to a new page that has
an embedded iframe of "slackin" running on Now.

FAQ page amended to get people to ask questions
on slack rather than create issues.

Footer of all pages changed to add social icon and
link to openj9 slack.

Other minor change. Date added to Whats new entry
about OpenJDK8 and OpenJ9.

Issue is
https://github.com/eclipse/openj9/issues/627

Issue: #627

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>