### PR TITLE
Update Copyright headers, fix V8 build dir names

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ OpenJDK Assembly Exception [2].
 [1] https://www.gnu.org/software/classpath/license.html
 [2] http://openjdk.java.net/legal/assembly-exception.html
 
-SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 # Eclipse OpenJ9 website
 
@@ -47,7 +47,7 @@ Also note that it can take a few minutes for the contents of the staging website
 ## OpenJ9 license information
 
 ```
-Copyright (c) 2017 IBM Corp. and others
+Copyright (c) 2017, 2018 IBM Corp. and others
 
 This program and the accompanying materials are made available under
  the terms of the Eclipse Public License 2.0 which accompanies this
@@ -65,5 +65,5 @@ with the OpenJDK Assembly Exception [2]. 
 [1] https://www.gnu.org/software/classpath/license.html  
 [2] http://openjdk.java.net/legal/assembly-exception.html 
 
-SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ```

--- a/benchmark/daytrader3.md
+++ b/benchmark/daytrader3.md
@@ -1,3 +1,25 @@
+<!--
+Copyright (c) 2017, 2018 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+ 
 Measuring the strengths of OpenJDK with Eclipse OpenJ9
 ======================================================
 
@@ -167,7 +189,7 @@ To simulate a CPU constrained environment, the JVM process was pinned to a singl
 -Xscmx150M -Xscmaxaot120m -Xtune:virtualized
 ```
 
-Copyright (c) 2017 IBM Corp. and others
+Copyright (c) 2017, 2018 IBM Corp. and others
 
 ---
 

--- a/css/oj9_common.css
+++ b/css/oj9_common.css
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2017 IBM Corp. and others
+Copyright (c) 2017, 2018 IBM Corp. and others
 
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution and is available at http://eclipse.org/legal/epl-2.0 or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0. 
 
@@ -8,7 +8,7 @@ This Source Code may also be made available under the following Secondary Licens
 [1] https://www.gnu.org/software/classpath/license.html  
 [2] http://openjdk.java.net/legal/assembly-exception.html 
 
-SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  */
 
 

--- a/css/oj9_media.css
+++ b/css/oj9_media.css
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2017 IBM Corp. and others
+Copyright (c) 2017, 2018 IBM Corp. and others
 
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution and is available at http://eclipse.org/legal/epl-2.0 or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0. 
 
@@ -8,7 +8,7 @@ This Source Code may also be made available under the following Secondary Licens
 [1] https://www.gnu.org/software/classpath/license.html  
 [2] http://openjdk.java.net/legal/assembly-exception.html 
 
-SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  */
 
 

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-Copyright (c) 2017 IBM Corp. and others
+Copyright (c) 2017, 2018 IBM Corp. and others
 
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution and is available at http://eclipse.org/legal/epl-2.0 or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0. 
 
@@ -9,7 +9,7 @@ This Source Code may also be made available under the following Secondary Licens
 [1] https://www.gnu.org/software/classpath/license.html  
 [2] http://openjdk.java.net/legal/assembly-exception.html 
 
-SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 <html lang="en">
 <head>

--- a/jenkinsMirror
+++ b/jenkinsMirror
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -17,7 +17,7 @@
  * [1] https://www.gnu.org/software/classpath/license.html
  * [2] http://openjdk.java.net/legal/assembly-exception.html
  *
- * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
  
 pipeline {

--- a/jenkinsPullRequests
+++ b/jenkinsPullRequests
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -17,7 +17,7 @@
  * [1] https://www.gnu.org/software/classpath/license.html
  * [2] http://openjdk.java.net/legal/assembly-exception.html
  *
- * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
 pipeline {

--- a/js/app.js
+++ b/js/app.js
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2017 IBM Corp. and others
+Copyright (c) 2017, 2018 IBM Corp. and others
 
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution and is available at http://eclipse.org/legal/epl-2.0 or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0. 
 
@@ -8,7 +8,7 @@ This Source Code may also be made available under the following Secondary Licens
 [1] https://www.gnu.org/software/classpath/license.html  
 [2] http://openjdk.java.net/legal/assembly-exception.html 
 
-SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  */
 var readMoreButton = document.getElementById('read-more-button');
 var readMoreButtonIcon = document.getElementById('read-more-button-icon');

--- a/js/oj9_common.js
+++ b/js/oj9_common.js
@@ -1,4 +1,17 @@
-﻿function test(url) {
+﻿/*
+Copyright (c) 2017, 2018 IBM Corp. and others
+
+This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution and is available at http://eclipse.org/legal/epl-2.0 or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0. 
+
+This Source Code may also be made available under the following Secondary Licenses when the conditions for such availability set forth in the Eclipse Public License, v. 2.0 are satisfied: GNU General Public License, version 2 with the GNU Classpath Exception [1] and GNU General Public License, version 2 with the OpenJDK Assembly Exception [2]. 
+
+[1] https://www.gnu.org/software/classpath/license.html  
+[2] http://openjdk.java.net/legal/assembly-exception.html 
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ */
+ 
+ function test(url) {
 //this removes the anchor at the end, if there is one
 url = url.substring(0, (url.indexOf("#") == -1) ? url.length : url.indexOf("#"));
 //this removes the query after the file name, if there is one

--- a/oj9_build.html
+++ b/oj9_build.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-Copyright (c) 2017 IBM Corp. and others
+Copyright (c) 2017, 2018 IBM Corp. and others
 
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution and is available at http://eclipse.org/legal/epl-2.0 or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0. 
 
@@ -9,7 +9,7 @@ This Source Code may also be made available under the following Secondary Licens
 [1] https://www.gnu.org/software/classpath/license.html  
 [2] http://openjdk.java.net/legal/assembly-exception.html 
 
-SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 <html lang="en">
 <head>
@@ -225,7 +225,11 @@ input[type="radio"]:checked + label {
           <pre><code>make all</code></pre>
           <p>Two Java builds are produced: a full developer kit (<code>jdk</code>) and a runtime environment (<code>jre</code>):
           </p>
-          <ul>
+          <ul class="v-8">
+            <li><code>build/&lt;platform&gt;/images/j2sdk-image</code></li>
+            <li><code>build/&lt;platform&gt;/images/j2re-image</code></li>
+          </ul>
+		  <ul class="v-9">
             <li><code>build/&lt;platform&gt;/images/jdk</code></li>
             <li><code>build/&lt;platform&gt;/images/jre</code></li>
           </ul>
@@ -242,7 +246,9 @@ input[type="radio"]:checked + label {
           <h3>Test</h3>
           <p>For a simple test, try running the <code>java -version</code> command.
           </p>
-          <pre><code>cd build/&lt;platform&gt;/images/jre</code>
+          <pre class="v-8"><code>cd build/&lt;platform&gt;/images/j2re-image</code>
+<code>./bin/java -version</code></pre>
+		  <pre class="v-9"><code>cd build/&lt;platform&gt;/images/jre</code>
 <code>./bin/java -version</code></pre>
           <p>Here is a sample of the output from a Linux x-86 binary:
           </p>

--- a/oj9_faq.html
+++ b/oj9_faq.html
@@ -1,7 +1,7 @@
   <script type="text/javascript" src="./js/oj9_common.js"></script>
 <!DOCTYPE html>
 <!--
-Copyright (c) 2017 IBM Corp. and others
+Copyright (c) 2017, 2018 IBM Corp. and others
 
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution and is available at http://eclipse.org/legal/epl-2.0 or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0. 
 
@@ -10,7 +10,7 @@ This Source Code may also be made available under the following Secondary Licens
 [1] https://www.gnu.org/software/classpath/license.html  
 [2] http://openjdk.java.net/legal/assembly-exception.html 
 
-SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 <html lang="en">
 <head>

--- a/oj9_joinslack.html
+++ b/oj9_joinslack.html
@@ -1,7 +1,7 @@
   <script type="text/javascript" src="./js/oj9_common.js"></script>
 <!DOCTYPE html>
 <!--
-Copyright (c) 2017 IBM Corp. and others
+Copyright (c) 2017, 2018 IBM Corp. and others
 
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution and is available at http://eclipse.org/legal/epl-2.0 or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0. 
 
@@ -10,7 +10,7 @@ This Source Code may also be made available under the following Secondary Licens
 [1] https://www.gnu.org/software/classpath/license.html  
 [2] http://openjdk.java.net/legal/assembly-exception.html 
 
-SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 <html lang="en">
 <head>

--- a/oj9_performance.html
+++ b/oj9_performance.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-Copyright (c) 2017 IBM Corp. and others
+Copyright (c) 2017, 2018 IBM Corp. and others
 
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution and is available at http://eclipse.org/legal/epl-2.0 or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0. 
 
@@ -9,7 +9,7 @@ This Source Code may also be made available under the following Secondary Licens
 [1] https://www.gnu.org/software/classpath/license.html  
 [2] http://openjdk.java.net/legal/assembly-exception.html 
 
-SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 <html lang="en">
 <head>

--- a/oj9_resources.html
+++ b/oj9_resources.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-Copyright (c) 2017 IBM Corp. and others
+Copyright (c) 2017, 2018 IBM Corp. and others
 
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution and is available at http://eclipse.org/legal/epl-2.0 or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0. 
 
@@ -9,7 +9,7 @@ This Source Code may also be made available under the following Secondary Licens
 [1] https://www.gnu.org/software/classpath/license.html  
 [2] http://openjdk.java.net/legal/assembly-exception.html 
 
-SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 <html lang="en">
 <head>

--- a/oj9_whatsnew.html
+++ b/oj9_whatsnew.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-Copyright (c) 2017 IBM Corp. and others
+Copyright (c) 2017, 2018 IBM Corp. and others
 
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution and is available at http://eclipse.org/legal/epl-2.0 or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0. 
 
@@ -9,7 +9,7 @@ This Source Code may also be made available under the following Secondary Licens
 [1] https://www.gnu.org/software/classpath/license.html  
 [2] http://openjdk.java.net/legal/assembly-exception.html 
 
-SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 <html lang="en">
 <head>


### PR DESCRIPTION
Update copyright headers for 2017, 2018 and
replace SPDX-License-Identifier line as per
openj9 source. Issue #55

OpenJDK 8 build image directories are not the
same as V9. Fix as per issue #65

Fixes: #55
Fixes: #56

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>