### PR TITLE
Add information about OpenJ9 hangouts

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,12 +176,12 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
       <div class="f-section-item">
         <div class="f-content-container">
           <p><span class="first-word">Ask questions</span>
-          If you get stuck trying to do something, <a href="oj9_joinslack.html">join our Slack channel</a> where you can get some help from the community. Our developers also monitor <code class="stack">#OpenJ9</code> questions on Stack Overflow. For very general questions about OpenJ9 and how it fits into the OpenJDK ecosystem, we've created an <a href="oj9_faq.html">FAQ</a>.
+          If you get stuck trying to do something, <a href="oj9_joinslack.html">join our Slack workspace</a> where you can get some help from the community. Our developers also monitor <code class="stack">#OpenJ9</code> questions on Stack Overflow. For very general questions about OpenJ9 and how it fits into the OpenJDK ecosystem, we've created an <a href="oj9_faq.html">FAQ</a>.
           </p>
         </div>
         <div class="f-button-container">
           <a class="button external-button left-half" href="oj9_joinslack.html">Join</a>
-          <a class="button external-button right-half" href="https://openj9.slack.com/" target="_blank">Slack channel<i class="fa fa-slack" aria-hidden="true"></i></a>
+          <a class="button external-button right-half" href="https://openj9.slack.com/" target="_blank">OpenJ9 Slack<i class="fa fa-slack" aria-hidden="true"></i></a>
 		  <br>
 		  <a class="button external-button" href="https://stackoverflow.com/search?q=%23OpenJ9" target="_blank">Stack Overflow<i class="fa fa-stack-overflow" aria-hidden="true"></i></a>
         </div>
@@ -212,7 +212,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
      <div class="f-section-item">
         <div class="f-content-container">
           <p><span class="first-word">Make suggestions</span>
-          If you are using OpenJ9 within a Java runtime environment and you have ideas for improvements, share them in our <a href="href="https://openj9.slack.com">slack channel</a> (Join <a href="oj9_joinslack.html">here</a>). We'd love to hear from you.
+          If you are using OpenJ9 within a Java runtime environment and you have ideas for improvements, share them in our <a href="href="https://openj9.slack.com">slack workspace</a> (Join <a href="oj9_joinslack.html">here</a>). We'd love to hear from you.
           </p>
         </div>
       </div>
@@ -221,6 +221,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
         <div class="f-content-container">
           <p><span class="first-word">Contribute</span>
           If you are interested in contributing to the development of this open-source project, check out the <a href="https://github.com/eclipse/openj9/blob/master/CONTRIBUTING.md">contribution guide</a> in our GitHub repository.
+		  If you want to find out more about how we work, why not come along to one of our <a href="oj9_whatsnew.html#hangout">hangouts</a>.
 		  You can also find out more about the project, including release plans, at our <a href="https://projects.eclipse.org/projects/technology.openj9">Eclipse Foundation project page</a>.
           </p>
         </div>
@@ -228,7 +229,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	  <div class="f-section-item">
         <div class="f-button-container">
-          <a class="button external-button" href="https://openj9.slack.com" target="_blank">Slack channel 
+          <a class="button external-button" href="https://openj9.slack.com" target="_blank">OpenJ9 Slack 
           <i class="fa fa-slack" aria-hidden="true"></i>
           </a>
 	  </div>
@@ -261,6 +262,11 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<div class="social-icon">
       <a href="https://openj9.slack.com/" target="_blank" title="Slack">
       	<i class="fa fa-slack" aria-hidden="true" style="font-size:2rem;"></i>
+      </a>
+    </div>
+	<div class="social-icon">
+      <a href="https://twitter.com/openj9/" target="_blank" title="Twitter">
+      	<i class="fa fa-twitter" aria-hidden="true" style="font-size:2rem;"></i>
       </a>
     </div>
     <div class="social-icon">

--- a/oj9_build.html
+++ b/oj9_build.html
@@ -338,6 +338,11 @@ OpenJDK  - 8593b2f based on )
       	<i class="fa fa-slack" aria-hidden="true" style="font-size:2rem;"></i>
       </a>
     </div>
+	<div class="social-icon">
+      <a href="https://twitter.com/openj9/" target="_blank" title="Twitter">
+      	<i class="fa fa-twitter" aria-hidden="true" style="font-size:2rem;"></i>
+      </a>
+    </div>
     <div class="social-icon">
       <a href="https://stackoverflow.com/search?q=%23OpenJ9" target="_blank" title="Stack Overflow">
         <i class="fa fa-stack-overflow" aria-hidden="true" style="font-size: 2rem;"></i>

--- a/oj9_faq.html
+++ b/oj9_faq.html
@@ -53,7 +53,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
       <h1>Frequently asked questions</h1>
 
       <div class="f-section-item">
-        <span class="intro-text">This FAQ answers common questions about Eclipse OpenJ9 and how it fits into the OpenJDK ecosystem. If you can't find the answer you're looking for, ask a question in our <a href="openj9.slack.com">Slack community</a>, which you can join <a href="oj9_joinslack.html">here</a>.</span>
+        <span class="intro-text">This FAQ answers common questions about Eclipse OpenJ9 and how it fits into the OpenJDK ecosystem. If you can't find the answer you're looking for, ask a question in our <a href="openj9.slack.com">Slack workspace</a>,<br> which you can join <a href="oj9_joinslack.html">here</a>.</span>
       </div>
 
       <div class="section-item-faq">
@@ -95,6 +95,20 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
           <summary>What license is Eclipse OpenJ9 made available under?</summary>
           <p>The project license is Eclipse Public License 2.0 and Apache License, Version 2.0 (you can choose), but the EPLv2 license has a secondary compatibility for the GPL v2 that is used by OpenJDK. You can combine the two projects and use them together (as OpenJDK's GPL v2 of course). The full license is documented in the <a href="https://github.com/eclipse/openj9/blob/master/LICENSE">LICENSE file</a> and also summarized at the top of virtually every file in the <a href="http://github.com/eclipse/openj9">Eclipse OpenJ9 GitHub repository</a>.
           </p>
+        </details>
+      </div>
+ 
+	  <div class="section-item-faq">
+        <details id="engage">
+          <summary>How can I discuss ideas and provide feedback to this community?</summary>
+          <p>There are a number of ways that you can engage with the OpenJ9 community:
+		   <ul>
+			<li>Join our <a href="https://openj9.slack.com/messages/C8312LCV9/">OpenJ9 slack workspace</a> where you can collaborate directly with developers and other contributors on the project. To join slack, <a href="https://www.eclipse.org/openj9/oj9_joinslack.html">request an invitation.</a></li>
+			<li>Join the <a href="https://dev.eclipse.org/mailman/listinfo/openj9-dev">Eclipse mailing list</a> and post a message to our development community.</li>
+			<li>Come along to our regular hangouts, where you can speak to OpenJ9 developers directly, ask questions, and share your experiences. Schedules and agendas for hangouts are posted in the #planning channel of the OpenJ9 slack workspace.</li>
+			<li>Create an issue in our <a href="https://github.com/eclipse/openj9/issues">OpenJ9 GitHub repository</a>.</li>
+			<li>If you want to keep up to date with the latest news from the project, why not follow us on <a href="https://twitter.com/openj9">twitter</a>, <i>@openj9</i>.</li>
+		   </ul></p>
         </details>
       </div>
  
@@ -153,6 +167,11 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
     <div class="social-icon">
       <a href="https://openj9.slack.com/" target="_blank" title="Slack">
       	<i class="fa fa-slack" aria-hidden="true" style="font-size:2rem;"></i>
+      </a>
+    </div>
+	<div class="social-icon">
+      <a href="https://twitter.com/openj9/" target="_blank" title="Twitter">
+      	<i class="fa fa-twitter" aria-hidden="true" style="font-size:2rem;"></i>
       </a>
     </div>
     <div class="social-icon">

--- a/oj9_joinslack.html
+++ b/oj9_joinslack.html
@@ -80,6 +80,11 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
       	<i class="fa fa-slack" aria-hidden="true" style="font-size:2rem;"></i>
       </a>
     </div>
+	<div class="social-icon">
+      <a href="https://twitter.com/openj9/" target="_blank" title="Twitter">
+      	<i class="fa fa-twitter" aria-hidden="true" style="font-size:2rem;"></i>
+      </a>
+    </div>
     <div class="social-icon">
       <a href="https://stackoverflow.com/search?q=%23OpenJ9" target="_blank" title="Stack Overflow">
         <i class="fa fa-stack-overflow" aria-hidden="true" style="font-size: 2rem;"></i>

--- a/oj9_performance.html
+++ b/oj9_performance.html
@@ -289,6 +289,11 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
       	<i class="fa fa-slack" aria-hidden="true" style="font-size:2rem;"></i>
       </a>
     </div>
+	<div class="social-icon">
+      <a href="https://twitter.com/openj9/" target="_blank" title="Twitter">
+      	<i class="fa fa-twitter" aria-hidden="true" style="font-size:2rem;"></i>
+      </a>
+    </div>
     <div class="social-icon">
       <a href="https://stackoverflow.com/search?q=%23OpenJ9" target="_blank" title="Stack Overflow">
         <i class="fa fa-stack-overflow" aria-hidden="true" style="font-size: 2rem;"></i>

--- a/oj9_resources.html
+++ b/oj9_resources.html
@@ -135,6 +135,11 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
       	<i class="fa fa-slack" aria-hidden="true" style="font-size:2rem;"></i>
       </a>
     </div>
+	<div class="social-icon">
+      <a href="https://twitter.com/openj9/" target="_blank" title="Twitter">
+      	<i class="fa fa-twitter" aria-hidden="true" style="font-size:2rem;"></i>
+      </a>
+    </div>
     <div class="social-icon">
       <a href="https://stackoverflow.com/search?q=%23OpenJ9" target="_blank" title="Stack Overflow">
         <i class="fa fa-stack-overflow" aria-hidden="true" style="font-size: 2rem;"></i>

--- a/oj9_whatsnew.html
+++ b/oj9_whatsnew.html
@@ -54,13 +54,28 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
         <span class="intro-text">Covering anything from project news, events, milestones, and of course... new and cool stuff!</span>
       </div>
 
+	  <div class="f-section-item" id="hangout">
+        <div class="f-content-container">
+          <h3>Come <q>hangout</q> with the OpenJ9 community</h3>
+          <p><i>1st February 2018</i></p>
+          <p>Our regular community hangouts are a great place to meet the team and find out what is going on in the OpenJ9 project. 
+		  Everyone is welcome and the agenda is pretty flexible. Generally we discuss hot topics like release plans, issues, ideas, 
+		  and working processes, but we're open to requests. If you'd like to get involved at some level, why not come along? 
+		  Maybe you have some suggestions, or maybe you'd like to provide some feedback about your experiences using an OpenJDK 
+		  with OpenJ9. If you just want to come and listen, well that's fine too!</p>
+          <p>Schedules, agendas, minutes, and recordings are posted in the OpenJ9 slack workspace, in the #planning channel.
+		  To join slack:  <a href="oj9_joinslack.html">request an invitation</a>.
+          </p>
+        </div>
+      </div>
+	  
       <div class="f-section-item" id="slack_ga">
         <div class="f-content-container">
           <h3>Join us on slack</h3>
           <p><i>5th December 2017</i></p>
-          <p>We're pleased to announce the introduction of a new slack channel, which we hope will become a popular medium for collaborating with the OpenJ9 project team in addition to our Eclipse mailing list. Whether you have questions to ask or experiences to	share, we'd love to hear from you.
+          <p>We're pleased to announce the introduction of a new slack workspace, which we hope will become a popular medium for collaborating with the OpenJ9 project team in addition to our Eclipse mailing list. Whether you have questions to ask or experiences to	share, we'd love to hear from you.
           </p>
-          <p>Join the channel:  <a href="oj9_joinslack.html">request an invitation</a>.
+          <p>Join slack:  <a href="oj9_joinslack.html">request an invitation</a>.
           </p>
         </div>
       </div>
@@ -117,6 +132,11 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<div class="social-icon">
       <a href="https://openj9.slack.com/" target="_blank" title="Slack">
       	<i class="fa fa-slack" aria-hidden="true" style="font-size:2rem;"></i>
+      </a>
+    </div>
+	<div class="social-icon">
+      <a href="https://twitter.com/openj9/" target="_blank" title="Twitter">
+      	<i class="fa fa-twitter" aria-hidden="true" style="font-size:2rem;"></i>
       </a>
     </div>
     <div class="social-icon">


### PR DESCRIPTION
Add a what's new
Add an FAQ that lists how to engage, including
hangouts.
Update the home page to reference the hangouts
in "Contributing"
Add social icon for OpenJ9 twitter to all pages

fixes #59

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>