### PR TITLE
Integrate OpenJ9 hangout calendar into website

### DIFF
--- a/oj9_whatsnew.html
+++ b/oj9_whatsnew.html
@@ -63,7 +63,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		  and working processes, but we're open to requests. If you'd like to get involved at some level, why not come along? 
 		  Maybe you have some suggestions, or maybe you'd like to provide some feedback about your experiences using an OpenJDK 
 		  with OpenJ9. If you just want to come and listen, well that's fine too!</p>
-          <p>Schedules, agendas, minutes, and recordings are posted in the OpenJ9 slack workspace, in the #planning channel.
+		  <p>Schedules, agendas, minutes, and recordings are posted in the OpenJ9 slack workspace, in the #planning channel.
+		  <p>To update your Google calendar: <a target="_blank" href="https://calendar.google.com/calendar?cid=YjBnYjB0ZzNxaTZhb3NhZGZnbG0wa3BjY29AZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ">add OpenJ9 hangouts</a>.</p>
 		  To join slack:  <a href="oj9_joinslack.html">request an invitation</a>.
           </p>
         </div>


### PR DESCRIPTION
We now have a shared calendar for the OpenJ9
hangouts. Created a link so that people can
add the calendar to their google calendar
and embedded this in the website.

Closes #59

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>