### PR TITLE
Update slackin url due to new deployment

### DIFF
--- a/oj9_joinslack.html
+++ b/oj9_joinslack.html
@@ -58,7 +58,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	  <div class="f-section-item">
 		<div class="f-content-container">
-            <iframe src="https://slackin-ozuyyvpmac.now.sh/" height="450" width="400" style="border:2px solid gray;" scrolling="no" id="iframe"> ...
+            <iframe src="https://slackin-eqftwddakt.now.sh/" height="450" width="400" style="border:2px solid gray;" scrolling="no" id="iframe"> ...
 			</iframe>
         </div>
 	  </div>


### PR DESCRIPTION
This is a temporary solution.  Longer term we need to define an
alias for the slackin instance so we don't have to update the
website everytime we redeploy.

Fixes eclipse/openj9#1629

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>