### PR TITLE
Fix slack link

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,7 +212,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
      <div class="f-section-item">
         <div class="f-content-container">
           <p><span class="first-word">Make suggestions</span>
-          If you are using OpenJ9 within a Java runtime environment and you have ideas for improvements, share them in our <a href="href="https://openj9.slack.com">slack workspace</a> (Join <a href="oj9_joinslack.html">here</a>). We'd love to hear from you.
+          If you are using OpenJ9 within a Java runtime environment and you have ideas for improvements, share them in our <a href="https://openj9.slack.com">slack workspace</a> (Join <a href="oj9_joinslack.html">here</a>). We'd love to hear from you.
           </p>
         </div>
       </div>


### PR DESCRIPTION
The link to our slack instance on the index page is
bad. Fixing.

Closes: #76

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>