### PR TITLE
Add build information for non-compressedrefs builds

### DIFF
--- a/oj9_build.html
+++ b/oj9_build.html
@@ -163,6 +163,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <pre><code>bash ./configure --with-freemarker-jar=/root/freemarker.jar</code></pre>
           <p>Note that you must give an absolute path to <code>freemarker.jar</code>
           </p>
+          <p>If you require a larger heap size, enable a non-compressedrefs OpenJ9 build by adding the <code>--with-noncompressedrefs</code> option to this command.
+          </p>
         </div>
       </div>
 
@@ -350,6 +352,8 @@ OpenJDK  - 27f5b8f based on jdk8u152-b03)
           <pre><code>bash ./configure --with-freemarker-jar=/root/freemarker.jar</code></pre>
           <p>Note that you must give an absolute path to <code>freemarker.jar</code>
           </p>
+          <p>If you require a larger heap size, enable a non-compressedrefs OpenJ9 build by adding the <code>--with-noncompressedrefs</code> option to this command.
+          </p>
         </div>
       </div>
 
@@ -536,6 +540,8 @@ OpenJDK  - 1983043 based on jdk-9+181)
           </p>
           <pre><code>bash ./configure --with-freemarker-jar=/root/freemarker.jar</code></pre>
           <p>Note that you must give an absolute path to <code>freemarker.jar</code>
+          </p>
+          <p>If you require a larger heap size, enable a non-compressedrefs OpenJ9 build by adding the <code>--with-noncompressedrefs</code> option to this command.
           </p>
         </div>
       </div>


### PR DESCRIPTION
Making build information for https://github.com/eclipse/openj9/issues/1669 more visible.

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>