### PR TITLE
Add "not redistributable" clause to all website pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ OpenJDK Assembly Exception [2].
 [2] http://openjdk.java.net/legal/assembly-exception.html
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+The project website pages cannot be redistributed
 -->
 # Eclipse OpenJ9 website
 

--- a/benchmark/daytrader3.md
+++ b/benchmark/daytrader3.md
@@ -18,6 +18,8 @@ OpenJDK Assembly Exception [2].
 [2] http://openjdk.java.net/legal/assembly-exception.html
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+The project website pages cannot be redistributed
 -->
 
 # Measuring the strengths of OpenJDK 9 with Eclipse OpenJ9

--- a/benchmark/daytrader7.md
+++ b/benchmark/daytrader7.md
@@ -18,6 +18,8 @@ OpenJDK Assembly Exception [2].
 [2] http://openjdk.java.net/legal/assembly-exception.html
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+The project website pages cannot be redistributed
 -->
 
 # OpenJDK 8 performance with Eclipse OpenJ9

--- a/css/oj9_common.css
+++ b/css/oj9_common.css
@@ -5,6 +5,7 @@ This Source Code may also be made available under the following Secondary Licens
 [1] https://www.gnu.org/software/classpath/license.html  
 [2] http://openjdk.java.net/legal/assembly-exception.html 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ The project website pages cannot be redistributed 
  */
 
 

--- a/css/oj9_media.css
+++ b/css/oj9_media.css
@@ -9,6 +9,8 @@ This Source Code may also be made available under the following Secondary Licens
 [2] http://openjdk.java.net/legal/assembly-exception.html 
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+The project website pages cannot be redistributed
  */
 
 

--- a/index.html
+++ b/index.html
@@ -10,6 +10,8 @@ This Source Code may also be made available under the following Secondary Licens
 [2] http://openjdk.java.net/legal/assembly-exception.html 
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+The project website pages cannot be redistributed
 -->
 <html lang="en">
 <head>

--- a/js/app.js
+++ b/js/app.js
@@ -9,6 +9,7 @@ This Source Code may also be made available under the following Secondary Licens
 [2] http://openjdk.java.net/legal/assembly-exception.html 
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+The project website pages cannot be redistributed
  */
 var readMoreButton = document.getElementById('read-more-button');
 var readMoreButtonIcon = document.getElementById('read-more-button-icon');

--- a/js/oj9_common.js
+++ b/js/oj9_common.js
@@ -9,6 +9,7 @@ This Source Code may also be made available under the following Secondary Licens
 [2] http://openjdk.java.net/legal/assembly-exception.html 
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+The project website pages cannot be redistributed
  */
  
  function test(url) {

--- a/oj9_build.html
+++ b/oj9_build.html
@@ -10,6 +10,8 @@ This Source Code may also be made available under the following Secondary Licens
 [2] http://openjdk.java.net/legal/assembly-exception.html 
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+The project website pages cannot be redistributed
 -->
 <html lang="en">
 <head>

--- a/oj9_faq.html
+++ b/oj9_faq.html
@@ -12,6 +12,8 @@ This Source Code may also be made available under the following Secondary Licens
 [2] http://openjdk.java.net/legal/assembly-exception.html 
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+The project website pages cannot be redistributed
 -->
 <html lang="en">
 <head>

--- a/oj9_joinslack.html
+++ b/oj9_joinslack.html
@@ -11,6 +11,8 @@ This Source Code may also be made available under the following Secondary Licens
 [2] http://openjdk.java.net/legal/assembly-exception.html 
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+The project website pages cannot be redistributed
 -->
 <html lang="en">
 <head>

--- a/oj9_performance.html
+++ b/oj9_performance.html
@@ -9,7 +9,9 @@ This Source Code may also be made available under the following Secondary Licens
 [1] https://www.gnu.org/software/classpath/license.html  
 [2] http://openjdk.java.net/legal/assembly-exception.html 
 
-SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+The project website pages cannot be redistributed
 -->
 <html lang="en">
 <head>

--- a/oj9_resources.html
+++ b/oj9_resources.html
@@ -9,7 +9,9 @@ This Source Code may also be made available under the following Secondary Licens
 [1] https://www.gnu.org/software/classpath/license.html  
 [2] http://openjdk.java.net/legal/assembly-exception.html 
 
-SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+The project website pages cannot be redistributed
 -->
 <html lang="en">
 <head>

--- a/oj9_whatsnew.html
+++ b/oj9_whatsnew.html
@@ -1,11 +1,17 @@
 <!DOCTYPE html>
 <!--
-Copyright (c) 2017, 2018 IBM Corp. and others
-This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution and is available at http://eclipse.org/legal/epl-2.0 or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0. 
-This Source Code may also be made available under the following Secondary Licenses when the conditions for such availability set forth in the Eclipse Public License, v. 2.0 are satisfied: GNU General Public License, version 2 with the GNU Classpath Exception [1] and GNU General Public License, version 2 with the OpenJDK Assembly Exception [2]. 
-[1] https://www.gnu.org/software/classpath/license.html  
-[2] http://openjdk.java.net/legal/assembly-exception.html 
+Copyright (c) 2017 IBM Corp. and others
+
+This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution and is available at http://eclipse.org/legal/epl-2.0 or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0. 
+
+This Source Code may also be made available under the following Secondary Licenses when the conditions for such availability set forth in the Eclipse Public License, v. 2.0 are satisfied: GNU General Public License, version 2 with the GNU Classpath Exception [1] and GNU General Public License, version 2 with the OpenJDK Assembly Exception [2]. 
+
+[1] https://www.gnu.org/software/classpath/license.html  
+[2] http://openjdk.java.net/legal/assembly-exception.html 
+
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+The project website pages cannot be redistributed
 -->
 <html lang="en">
 <head>


### PR DESCRIPTION
As requested by the Eclipse IP team, we should indicate
that the website pages cannot be redistributed underneath
the licensing that we carry for the overall project.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>