### PR TITLE
Updates for v0.10.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         Want an OpenJDK&trade; build that contains an enterprise grade, open source, Java virtual machine?<br/>
         Grab a pre-built binary and try it for yourself...
       </p> 
-      <a class="button external-button" style="width:17em; margin-top:1rem;" href="https://adoptopenjdk.net/nightly.html?variant=openjdk8&jvmVariant=openj9">Download Now
+      <a class="button external-button" style="width:17em; margin-top:1rem;" href="https://adoptopenjdk.net/releases.html?variant=openjdk8&jvmVariant=openj9">Download Now
         <i class="fa fa-download" aria-hidden="true"></i></a>
 		
       <h2 id="performance" style="color: #65c1bd;">
@@ -149,7 +149,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           </p>
         </div>
         <div class="f-button-container">
-          <a class="button external-button" href="https://adoptopenjdk.net/nightly.html?variant=openjdk8&jvmVariant=openj9">Download it
+          <a class="button external-button" href="https://adoptopenjdk.net/releases.html?variant=openjdk8&jvmVariant=openj9">Download it
             <i class="fa fa-download" aria-hidden="true"></i></a>
         </div>
       </div>
@@ -157,7 +157,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       <div class="f-section-item">
         <div class="f-content-container">
           <p><span class="first-word">Build your own</span>
-          If you are familiar with building OpenJDK, you might want to build it with OpenJ9 yourself. For a deeper dive, read the build instructions, which cover all the steps to build a version 8 or version 9 OpenJDK with OpenJ9 and how to test your binary.
+          If you are familiar with building OpenJDK, you might want to build it with OpenJ9 yourself. For a deeper dive, read the build instructions, which cover all the steps to build an OpenJDK with OpenJ9 and how to test your binary.
           </p>
         </div>
         <div class="f-button-container">
@@ -170,9 +170,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <div class="f-content-container">
           <p><span class="first-word">Tune it</span>
           OpenJ9 optimizes your Java application out-of-the-box without needing a complicated set of command line options. However, further tuning is possible to improve your application's performance. For example, if your application has an extremely large heap, you might choose a different garbage collection policy to improve memory management. Alternatively, you might want to exploit specific hardware features such as a graphics processing unit (GPU).
-          </p>
-          <p>To learn more about tuning OpenJ9 for your application runtime environment, read the existing user documentation in the IBM Knowledge Center. Documentation to support OpenJ9 at the Eclipse foundation is a work in progress. Watch this space!
-          </p>
+          To learn more about tuning OpenJ9 for your application runtime environment, read the docs.</p>
         </div>
         <div class="f-button-container">
           <a class="button external-button" href="https://www.eclipse.org/openj9/docs/" target="_blank">Read the docs
@@ -183,7 +181,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       <div class="f-section-item">
         <div class="f-content-container">
           <p><span class="first-word">Ask questions</span>
-          If you get stuck trying to do something, <a href="oj9_joinslack.html">join our Slack workspace</a> where you can get some help from the community. Our developers also monitor <code class="stack">#OpenJ9</code> questions on Stack Overflow. For very general questions about OpenJ9 and how it fits into the OpenJDK ecosystem, we've created an <a href="oj9_faq.html">FAQ</a>.
+          If you get stuck trying to do something, join our Slack workspace where you can get some help from the community. Our developers also monitor <code class="stack">#OpenJ9</code> questions on Stack Overflow. For very general questions about OpenJ9, what we support, and how it fits into the OpenJDK ecosystem, we've created an <a href="oj9_faq.html">FAQ</a>.
           </p>
         </div>
         <div class="f-button-container">
@@ -219,7 +217,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
      <div class="f-section-item">
         <div class="f-content-container">
           <p><span class="first-word">Make suggestions</span>
-          If you are using OpenJ9 within a Java runtime environment and you have ideas for improvements, share them in our <a href="https://openj9.slack.com">slack workspace</a> (Join <a href="oj9_joinslack.html">here</a>). We'd love to hear from you.
+          If you are using OpenJ9 within a Java runtime environment and you have ideas for improvements, share them in our slack workspace (Join <a href="oj9_joinslack.html">here</a>). We'd love to hear from you.
           </p>
         </div>
       </div>
@@ -228,7 +226,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <div class="f-content-container">
           <p><span class="first-word">Contribute</span>
           If you are interested in contributing to the development of this open-source project, check out the <a href="https://github.com/eclipse/openj9/blob/master/CONTRIBUTING.md">contribution guide</a> in our GitHub repository.
-		  If you want to find out more about how we work, why not come along to one of our <a href="oj9_whatsnew.html#hangout">hangouts</a>.
+		  If you want to find out more about how we work, why not come along to one of our <a href="oj9_whatsnew.html#hangout">community calls</a>.
 		  You can also find out more about the project, including release plans, at our <a href="https://projects.eclipse.org/projects/technology.openj9">Eclipse Foundation project page</a>.
           </p>
         </div>

--- a/oj9_faq.html
+++ b/oj9_faq.html
@@ -104,7 +104,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
       <div class="section-item-faq">
         <details id="support">
-          <summary>Which system environments is Eclipse OpenJ9 supported on?</summary>
+          <summary>Which OpenJDK versions and which platforms is Eclipse OpenJ9 supported on?</summary>
           <p>You can find a full support statement in our <a href="https://www.eclipse.org/openj9/docs/openj9_support/" target="_blank">user documentation</a>.
           </p>
         </details>

--- a/oj9_whatsnew.html
+++ b/oj9_whatsnew.html
@@ -77,14 +77,51 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <div class="f-section-item">
         <span class="intro-text">Covering project news, events, milestones, and of course... new and cool stuff!</span>
       </div>
+	<div class="f-section-item" id="openj90100">
+    
+    <div class="f-content-container">
+          <h3>Eclipse OpenJ9 version 0.10.0 released</h3>
+          <p><i>3rd October 2018</i></p>
+          <p>Eclipse OpenJ9 version 0.10.0 adds support for OpenJDK version 11. All the testing we've done so far proves
+		  that builds are compatible with OpenJDK 11 and we expect builds to be available at  <a href="https://adoptopenjdk.net" target="_blank">AdoptOpenJDK</a> very soon.</p>
+		  
+		  <p>To learn more about our release strategy, plus our supported architectures and operating systems, 
+		  see <a href="https://www.eclipse.org/openj9/docs/openj9_support/index.html">Supported environments</a>.</p>
+
+		  <p>To help users adopt OpenJ9 we have been busy adding compatibility for a number of Hotspot options. We 
+		  are also writing content for the user documentation to help you compare Hotspot and OpenJ9 non-standard options and 
+		  garbage collection policies. So if you haven't already tried an OpenJDK with OpenJ9 or you've stumbled into problems 
+		  because command-line options you are familiar with are not recognised, we're working hard to improve the experience. If
+		  you have a migration problem, please help us out by posting details in our GitHub <a href="https://github.com/eclipse/openj9/issues/2332">issue</a>.
+		  </p>	
+		  		
+		<p>To read about other enhancements and notable changes in this release, see our <a href="https://www.eclipse.org/openj9/docs/version0.10/"><i>What's new</i></a> topic. 
+		  </p>
+		  
+
+
+		  
+		  
+
+<!-- Keep as-is except edit ID in URL and change "text=" -->
+<a href="https://twitter.com/share?
+url=https%3A%2F%2Fwww.eclipse.org%2Fopenj9%2Foj9_whatsnew.html%23openj90100&
+via=openj9&
+hashtags=openj9,java&
+text=V0.10.0%20released;%20OpenJDK%20v11%20builds%20now%20available."
+class="twitter-share-button"
+data-show-count="false">Tweet</a>
+        </div>
+	</div>	  
+	  
 	<div class="f-section-item" id="openj9090">
     
     <div class="f-content-container">
           <h3>Eclipse OpenJ9 version 0.9.0 released</h3>
-          <p><i>2nd August 2018</i></p>
+          <p><i>15th August 2018</i></p>
           <p>We're pleased to announce the release of Eclipse OpenJ9 version 0.9.0.</p>
 		  <p>V0.9.0 adds support for OpenJDK 10 builds, OpenJDK 8 Windows 32-bit builds, and OpenJDK large heap builds 
-		  that require Java heap sizes > 57 GB.
+		  that support Java heap sizes > 57 GB.
 		  Work is underway to make these builds available at  <a href="https://adoptopenjdk.net" target="_blank">AdoptOpenJDK</a>. 
 		  If you want a large heap binary for a platform other than 
 		  <a href="https://adoptopenjdk.net/nightly.html?variant=openjdk8-openj9" target="_blank">OpenJDK 8 


### PR DESCRIPTION
Added a new section for 0.10.0 to the What's new page.

Updated the home page to remove references to OpenJDK
versions, tweak the download button URL target (releases
not nightlies) and do a little decluttering of links
(feedback from design review). Also added a couple of
words to direct people to the FAQ for what we support.

Removed references to IBM Knowledge Center now that our
user docs are growing.

Updated the FAQ support question to make it clearer
(OpenJDK versions and platforms)

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>