### PR TITLE
WIP: Create more hyperlinks in the front page

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,6 +63,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
          <a href="./oj9_performance.html#g3">Fast startup time</a>
          <br/>
          <a href="./oj9_performance.html#g4">High application throughput</a>
+         <br/>
+         <a href="./oj9_performance.html#g5">Smoother ramp-up in the cloud</a>
       </span>
       </p>
       <p style="font-size:1.2rem;">

--- a/index.html
+++ b/index.html
@@ -57,7 +57,13 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!--
           <img src="./assets/openj9-hex.png" class="product-logo" />
 -->
-      <span style="font-size:1.4rem;color: #65c1bd;">Low memory footprint<br/>Fast startup time<br/>High application throughput</span>
+      <span style="font-size:1.4rem;color: #65c1bd;">
+         <a href="./oj9_performance.html#g1">Low memory footprint</a>
+         <br/>
+         <a href="./oj9_performance.html#g3">Fast startup time</a>
+         <br/>
+         <a href="./oj9_performance.html#g4">High application throughput</a>
+      </span>
       </p>
       <p style="font-size:1.2rem;">
         Eclipse OpenJ9 is optimized to run Java applications cost-effectively in the cloud.<br/>

--- a/index.html
+++ b/index.html
@@ -76,8 +76,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <i class="fa fa-download" aria-hidden="true"></i></a>
 		
       <h2 id="performance" style="color: #65c1bd;">
-        Give your Java application a thrill<br/>
-        Run it on OpenJDK with Eclipse OpenJ9
+        <a href="https://adoptopenjdk.net/nightly.html?variant=openjdk8&jvmVariant=openj9">Give your Java application a thrill<br/>
+        Run it on OpenJDK with Eclipse OpenJ9</a>
       </h2> 
 
 <!--

--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </span>
       </p>
       <p style="font-size:1.2rem;">
-        Eclipse OpenJ9 is optimized to run Java applications cost-effectively in the cloud.<br/>
+        <a href="./oj9_performance.html">Eclipse OpenJ9 is optimized to run Java applications cost-effectively in the cloud.</a><br/>
         Want an OpenJDK&trade; build that contains an enterprise grade, open source, Java virtual machine?<br/>
         Grab a pre-built binary and try it for yourself...
       </p> 


### PR DESCRIPTION
This set of changes turns more of the text into appropriate links. In particular:
1) Make the main performance claims link to the performance data backing up the claim
2) Add a performance claim for our smoother rampup
3) Changes the "optimized for the cloud" claim to a link to the performance data page
4_ Makes the "Try it out..." text link to the appropriate download page.

Fixes: #115 