### PR TITLE
point to the adoptopenjdk8 release builds instead of nightlies

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         Want an OpenJDK&trade; build that contains an enterprise grade, open source, Java virtual machine?<br/>
         Grab a pre-built binary and try it for yourself...
       </p> 
-      <a class="button external-button" style="width:17em; margin-top:1rem;" href="https://adoptopenjdk.net/nightly.html?variant=openjdk8&jvmVariant=openj9">Download Now
+      <a class="button external-button" style="width:17em; margin-top:1rem;"href="https://adoptopenjdk.net/releases.html?variant=openjdk8&jvmVariant=openj9">Download Now
         <i class="fa fa-download" aria-hidden="true"></i></a>
 		
       <h2 id="performance" style="color: #65c1bd;">


### PR DESCRIPTION
We should be pointing at the fully tested release builds at adoptopenjdk instead of the nightly builds