### PR TITLE
Add performance stats link to the front page

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       <span style="font-size:1.4rem;color: #65c1bd;">Low memory footprint<br/>Fast startup time<br/>High application throughput</span>
       </p>
       <p style="font-size:1.2rem;">
-        Eclipse OpenJ9 is optimized to run Java applications cost-effectively in the cloud.<br/>
+        Eclipse OpenJ9 is optimized to run Java applications cost-effectively in the cloud.
+        <span class="read-more-link">Learn more about <a href="oj9_performance.html">Check out the performance stats for yourself</a><br/></span>
         Want an OpenJDK&trade; build that contains an enterprise grade, open source, Java virtual machine?<br/>
         Grab a pre-built binary and try it for yourself...
       </p> 


### PR DESCRIPTION
Include a link on the front page that allows people to get quickly to the reasons why they'd chose an OpenJ9 VM instead of having to click "Read More" and finding the link right down at the bottom of that section. We need to put this information in a readily accessible place.