### PR TITLE
Add a link to evidence that backs up perf claims

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,17 +57,17 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!--
           <img src="./assets/openj9-hex.png" class="product-logo" />
 -->
-      <span style="font-size:1.4rem;color: #65c1bd;">Low memory footprint<br/>Fast startup time<br/>High application throughput</span>
+      <span style="font-size:1.4rem;">Low memory footprint<br/>Fast startup time<br/>High application throughput<br/>Smoother ramp-up in the cloud</span>
       </p>
       <p style="font-size:1.2rem;">
-        Eclipse OpenJ9 is optimized to run Java applications cost-effectively in the cloud.<br/>
+        <a href="oj9_performance.html">Show me the data!</a><br/><br/>
         Want an OpenJDK&trade; build that contains an enterprise grade, open source, Java virtual machine?<br/>
         Grab a pre-built binary and try it for yourself...
       </p> 
       <a class="button external-button" style="width:17em; margin-top:1rem;" href="https://adoptopenjdk.net/releases.html?variant=openjdk8&jvmVariant=openj9">Download Now
         <i class="fa fa-download" aria-hidden="true"></i></a>
 		
-      <h2 id="performance" style="color: #65c1bd;">
+      <h2 id="performance">
         Give your Java application a thrill<br/>
         Run it on OpenJDK with Eclipse OpenJ9
       </h2> 


### PR DESCRIPTION
Feedback from research and others suggests that our
3 performance claims in blue are mistaken for
hyperlinks.

Users also wanted to see evidence, but missed finding
the performance page. Our link to performance is in
the "learn more" or can be found in the menu, but we
need to make it more obvious.

Changing the 3 performance claims to hyperlinks creates
a UX issue ... too many links joined together.

This PR to gain feedback on adding a 4th claim suggested
by Mark Stoodley, and adding a link to our evidence
"Show me the data!"

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>