### PR TITLE
[WIP] Switch our current join slack slackin for a link

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       <p style="font-size:1.2rem;">
         <a href="oj9_performance.html">Show me the data!</a><br/><br/>
         Want an OpenJDK&trade; build that contains an enterprise grade, open source, Java virtual machine?<br/>
-        Grab a pre-built binary and try it for yourself...
+        Grab a pre-built binary for Linux, Windows, or macOS and try it for yourself...
       </p> 
       <a class="button external-button" style="width:17em; margin-top:1rem;" href="https://adoptopenjdk.net/releases.html?variant=openjdk8&jvmVariant=openj9">Download Now
         <i class="fa fa-download" aria-hidden="true"></i></a>
@@ -185,7 +185,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           </p>
         </div>
         <div class="f-button-container">
-          <a class="button external-button left-half" href="oj9_joinslack.html">Join</a>
+          <a class="button external-button left-half" href="https://join.slack.com/t/openj9/shared_invite/enQtNDU4MDI4Mjk0MTk2LWM2MjliMTQ4NWM5YjMwNTViOTgzMzM2ZDhlOWJmZTc1MjhmYmRjMDg2NDljNGM0YTAwOWRiZDE0YzI0NjgyOWI" target="_blank">Join</a>
           <a class="button external-button right-half" href="https://openj9.slack.com/" target="_blank">OpenJ9 Slack<i class="fa fa-slack" aria-hidden="true"></i></a>
 		  <br>
 		  <a class="button external-button" href="https://stackoverflow.com/search?q=%23OpenJ9" target="_blank">Stack Overflow<i class="fa fa-stack-overflow" aria-hidden="true"></i></a>
@@ -217,7 +217,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
      <div class="f-section-item">
         <div class="f-content-container">
           <p><span class="first-word">Make suggestions</span>
-          If you are using OpenJ9 within a Java runtime environment and you have ideas for improvements, share them in our slack workspace (Join <a href="oj9_joinslack.html">here</a>). We'd love to hear from you.
+          If you are using OpenJ9 within a Java runtime environment and you have ideas for improvements, share them in our slack workspace (<a href="https://join.slack.com/t/openj9/shared_invite/enQtNDU4MDI4Mjk0MTk2LWM2MjliMTQ4NWM5YjMwNTViOTgzMzM2ZDhlOWJmZTc1MjhmYmRjMDg2NDljNGM0YTAwOWRiZDE0YzI0NjgyOWI" target="_blank">Request an invite</a>). We'd love to hear from you.
           </p>
         </div>
       </div>

--- a/oj9_faq.html
+++ b/oj9_faq.html
@@ -57,7 +57,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       <h1>Frequently asked questions</h1>
 
       <div class="f-section-item">
-        <span class="intro-text">This FAQ answers common questions about Eclipse OpenJ9 and how it fits into the OpenJDK&trade; ecosystem.<br><br>If you can't find the answer you're looking for, ask a question in our <a href="openj9.slack.com">Slack workspace</a>, which you can join <a href="oj9_joinslack.html">here</a>.</span>
+        <span class="intro-text">This FAQ answers common questions about Eclipse OpenJ9 and how it fits into the OpenJDK&trade; ecosystem.<br><br>If you can't find the answer you're looking for, ask a question in our <a href="openj9.slack.com">Slack workspace</a> (<a href="https://join.slack.com/t/openj9/shared_invite/enQtNDU4MDI4Mjk0MTk2LWM2MjliMTQ4NWM5YjMwNTViOTgzMzM2ZDhlOWJmZTc1MjhmYmRjMDg2NDljNGM0YTAwOWRiZDE0YzI0NjgyOWI" target="_blank">request an invite</a>).</span>
       </div>
 
       <div class="section-item-faq">
@@ -115,7 +115,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <summary>How can I discuss ideas and provide feedback to this community?</summary>
           <p>There are a number of ways that you can engage with the OpenJ9 community:
 		   <ul>
-			<li>Join our <a href="https://openj9.slack.com/messages/C8312LCV9/" target="_blank">OpenJ9 slack workspace</a> where you can collaborate directly with developers and other contributors on the project. To join slack, <a href="https://www.eclipse.org/openj9/oj9_joinslack.html" target="_blank">request an invitation.</a></li>
+			<li>Join our <a href="https://openj9.slack.com/messages/C8312LCV9/" target="_blank">OpenJ9 slack workspace</a> where you can collaborate directly with developers and other contributors on the project. To join slack, <a href="https://join.slack.com/t/openj9/shared_invite/enQtNDU4MDI4Mjk0MTk2LWM2MjliMTQ4NWM5YjMwNTViOTgzMzM2ZDhlOWJmZTc1MjhmYmRjMDg2NDljNGM0YTAwOWRiZDE0YzI0NjgyOWI" target="_blank">request an invitation.</a></li>
 			<li>Join the <a href="https://dev.eclipse.org/mailman/listinfo/openj9-dev" target="_blank">Eclipse mailing list</a> and post a message to our development community.</li>
 			<li>Come along to our regular hangouts, where you can speak to OpenJ9 developers directly, ask questions, and share your experiences. Schedules and agendas for hangouts are posted in the #planning channel of the OpenJ9 slack workspace.</li>
 			<li>Create an issue in our <a href="https://github.com/eclipse/openj9/issues" target="_blank">OpenJ9 GitHub repository</a>.</li>


### PR DESCRIPTION
The slackin instance runs on a cloud service and
can sometimes be slow to load, leaving users
thinking that it is broken.

Replacing with a slack invite link in all places
where the slackin link exists.

Closes: #125

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>