### PR TITLE
Various fixes and improvements for Xdump and Xtrace Option Builders

### DIFF
--- a/tools/xdump_option_builder.html
+++ b/tools/xdump_option_builder.html
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
 TODO:
 - Add tooltips for *all* options?
 - Implement "none" option for turning agents off?
@@ -53,156 +53,182 @@ var noHeapdumpEventElementIds = ["event_gpf", "event_traceassert", "event_abort"
 var agentsThatDumpAFileIds = ["agent_system", "agent_java", "agent_heap", "agent_snap", "agent_jit"];
 
 function initialSetup() {
-    setupTooltips();
+	setupTooltips();
 	parseParams();
 }
 
 function setupTooltips() {
-    var titleText;
-	
+	var titleText;
+
 	titleText = "Filter on the fully qualified name of the Exception (or Error) class, to reduce the number of dump files " +
 	            "produced. Use slashes as package separators. Asterisks as wildcards are supported at the beginning of " +
 	            "the string, and/or at the end if no method filter is specified. Examples:\n\n" +
 	            "    - java/lang/OutOfMemoryError\n" +
 	            "    - *IOException";
 	document.getElementById("event_throwable_class").title = titleText;
-	
+
 	titleText = "Filter on a fully qualified method name to reduce the number of dump files produced. The default stack frame " +
 	            "offset is 0, which is the top stack frame - i.e. the method from which the Exception was thrown.\n\n" +
-				"Use slashes as package separators. Asterisks as wildcards are supported at the end of the string. Examples:\n\n" +
+	            "Use slashes as package separators. Asterisks as wildcards are supported at the end of the string. Examples:\n\n" +
 	            "    - java/lang/String.getBytes*\n" +
 	            "    - java/util/*";
 	document.getElementById("event_throwable_method").title = titleText;
-	
+
 	titleText = "Filter on text within the exception message, to reduce the number of dump files produced. Asterisks as " +
-	            "wildcards are supported at the beginning and/or end of the string. Supported on " +
-				"Java 8 and later only. Examples:\n\n" +
+	            "wildcards are supported at the beginning and/or end of the string. Examples:\n\n" +
 	            "    - *class format*\n" +
 	            "    - *access denied*\n";
 	document.getElementById("event_throwable_msg_filter").title = titleText;
-	
+
 	titleText = "The stack frame offset allows you to specify the position of the filtered method in the stack. This option is " +
 	            "useful if the exception is being thrown from a general purpose or utility class. " +
 	            "The default value is 0 (i.e. the top stack frame)";
 	document.getElementById("event_throwable_offset").title = titleText;
-	
+
 	titleText = "Filter on the fully qualified Class name, to reduce the number of dump files produced. Asterisks " +
 	            "as wildcards are supported at the beginning or end of the string. Use slashes as package separators. Examples:\n\n" +
 	            "    - java/lang/String" +
 	            "    - java/util/Hash*" +
 	            "    - *security*";
 	document.getElementById("event_class_filter").title = titleText;
-	
+
 	titleText = "One event can generate multiple dumps. The agents that produce each dump run sequentially and their order is " +
 	            "determined by the priority keyword set for each agent. Higher priority dump agents are started first. The " +
 	            "priorities associated with default dump agents can be view by running \"java -Xdump:what\".";
 	document.getElementById("priority_value").title = titleText;
+	
+	titleText = "Specify the range of dump events on which to trigger the specified dump agents. For example, if \"First event\" is set to 5, " +
+				"and \"Last event\" set to 7, the dump event will trigger only on the 5th, 6th and 7th dump events. A value of 0 means " +
+				"\"no limit\"\n\n" +
+				"The default is first = 1 and last = 0 except for when the shell command (tool) agent is enabled, whereby the default " +
+				" becomes first = 1 and last = 1.";
+	document.getElementById("range_li").title = titleText;
 }
 
 function parseParams() {
 	if (location.search != "") {
-        // Get the query part of the URL, remove the leading '?', and split on '&'
-        var params = location.search.substring(1).split("&"); // this includes the '?' so need to substring it
+		// Get the query part of the URL, remove the leading '?', and split on '&'
+		var params = location.search.substring(1).split("&"); // this includes the '?' so need to substring it
 
 		for (var i = 0; i < params.length; i++) {
-	        var param = params[i].split("=");
-    		var key = param[0];
-		    var value = param[1];
-    		
+			var param = params[i].split("=");
+			var key = param[0];
+			var value = param[1];
+    	
 			var element = document.getElementById(param[0]);
-		    			
+
 			if (element == null) {
-	        	console.log("ERROR: Key does not map to element: " + tracepointKey);
-			    continue; // Go to the next parameter
+				console.log("ERROR: Key does not map to element: " + key);
+				continue; // Go to the next parameter
 			}
-						
-		    switch (element.type) {
-    		    case "checkbox":
-			        switch (value) {
-			            case "0":
-				            element.checked = false;
-					        break;
-			    
-				        case "1":
-        				    element.checked = true;
-					        break;
-					
-				        default:
-        				    console.log("ERROR: Invalid value for checkbox element \"" + element.id + "\": " + value);
-			                continue; // Go to the next parameter
-			        }
+
+			switch (element.type) {
+				case "checkbox":
+					switch (value) {
+						case "0":
+							element.checked = false;
+							break;
+
+						case "1":
+							element.checked = true;
+							break;
+
+						default:
+							console.log("ERROR: Invalid value for checkbox element \"" + element.id + "\": " + value);
+							continue; // Go to the next parameter
+					}
 					break;
-				
-			    case "text":
-    			    element.value = decodeURIComponent(value);
-				    break;
-				
-			    case "number":
-    			    element.value = value;
-				    break;
-		    }
-		
-		    processChange(element);
-		    element.blur();
-	    }
+
+				case "text":
+					element.value = decodeURIComponent(value);
+					break;
+
+				case "number":
+					element.value = value;
+					break;
+			}
+
+			processChange(element);
+			element.blur();
+		}
 	} else {
-	    // If no parameters were provided, just build the result with the defaults
+		// If no parameters were provided, just build the result with the defaults
 		buildAndUpdateResult();
 	}
 }
 
 function processChange(option) {
-        	
+
 	if (option.name == "agent") {
-	    if (option.value == "tool") {
-		    var execFieldElement = document.getElementById("exec");
+		if (option.value == "tool") {
+			var execFieldElement = document.getElementById("exec");
+			var toolAsyncElement = document.getElementById("tool_async");
+			var toolWaitElement = document.getElementById("tool_wait");
+			
+			var rangeElement = document.getElementById("range");
+			var rangeFirstElement = document.getElementById("range_first");
+			var rangeLastElement = document.getElementById("range_last");
 			if (option.checked == true) {
-			    enableInput(execFieldElement);
+				// If range has not been modified, set it to the tool default of 1..1
+				if (rangeFirstElement.value == 1 && rangeLastElement.value == 0) {
+					rangeFirstElement.value = 1;
+					rangeLastElement.value = 1;
+				}
+				enableInput(execFieldElement);
+				enableInput(toolAsyncElement);
+				enableInput(toolWaitElement);
 				execFieldElement.focus();
 			} else {
-			    disableInput(execFieldElement);
+				// If has not been modified, set it to the normal default of 1..0
+				if (rangeFirstElement.value == 1 && rangeLastElement.value == 1) {
+					rangeFirstElement.value = 1;
+					rangeLastElement.value = 0;
+				}
+				disableInput(execFieldElement);
+				disableInput(toolAsyncElement);
+				disableInput(toolWaitElement);
 			}		
 		}
 
 		configureRequestOptions(option.value);
 	}
-	
+
 	// Prepwalk can only be checked if exclusive access is also checked
 	if (option.value == "prepwalk") {
-	    // Exclusive access must be checked if prepwalk is checked
-	    if (option.checked == true) {
-        	document.getElementById("request_exclusive").checked = true;
-	    }
+		// Exclusive access must be checked if prepwalk is checked
+		if (option.checked == true) {
+			document.getElementById("request_exclusive").checked = true;
+		}
 	} else if (option.value == "exclusive") {
-	    // If exclusive access gets unchecked, uncheck prepwalk
-	    if (option.checked == false) {
-        	document.getElementById("request_prepwalk").checked = false;
-	    }
+		// If exclusive access gets unchecked, uncheck prepwalk
+		if (option.checked == false) {
+			document.getElementById("request_prepwalk").checked = false;
+		}
 	}    
-	
+
 	// Enable range number fields when range is checked
 	if (option.name == "range") {
-	    if (option.checked == true) {
-    	    enableInput(document.getElementById("range_first"));
-            enableInput(document.getElementById("range_last"));			
-	    } else {
-		    disableInput(document.getElementById("range_first"));
-            disableInput(document.getElementById("range_last"));			
+		if (option.checked == true) {
+			enableInput(document.getElementById("range_first"));
+			enableInput(document.getElementById("range_last"));			
+		} else {
+			disableInput(document.getElementById("range_first"));
+			disableInput(document.getElementById("range_last"));			
 		}
-    }
-	
+	}
+
 	// Enable and focus priority number field when priority is checked
 	if (option.name == "priority") {
-	    var priorityValueElement = document.getElementById("priority_value");
+		var priorityValueElement = document.getElementById("priority_value");
 		if (option.checked == true) {
-    	    enableInput(priorityValueElement);
+			enableInput(priorityValueElement);
 			priorityValueElement.focus();
-        } else {
-		    disableInput(priorityValueElement);			
+		} else {
+			disableInput(priorityValueElement);			
 		}
-    }
-	
-    // Set a sensible default value for the range fields if the user enters an empty value
+	}
+
+	// Set a sensible default value for the range fields if the user enters an empty value
 	if (option.name == "range_first") {
 	    if (option.value == "") {
     	    option.value = 1;
@@ -212,115 +238,115 @@ function processChange(option) {
     	    option.value = 0;
 		}
 	}
-	
+
 	// Fix obvious mistakes in class name filters
 	if (option.name == "throwable_class" || option.name == "class_text") {
-	    // Remove any whitespace
+		// Remove any whitespace
 		option.value = option.value.replace(/\s/g,'');
-		
+
 		// Replace dots with slashes
 		option.value = option.value.replace(/\./g, "/");		
 	}
-	
+
 	// Attempt to correct common formatting mistakes in the method filter
 	if (option.name == "throwable_method") {
-	    // Remove any whitespace
+	// Remove any whitespace
 		option.value = option.value.replace(/\s/g,'');
-		
+
 		// Check for more than one dot in the string
 		if (option.value.indexOf(".") != -1 && (option.value.indexOf(".") != option.value.lastIndexOf("."))) {
-		    // Replace dots with slashes until there is only one dot left
+			// Replace dots with slashes until there is only one dot left
 			// This is a best effort, and isn't always going to work
 			while (option.value.indexOf(".") != option.value.lastIndexOf(".")) {
-			    option.value = option.value.replace(".", "/");
+				option.value = option.value.replace(".", "/");
 			}
-	    }	
+		}	
 	}
-		
+
 	// Enable/disable events that are incompatible with the one that has been changed
 	if (option.name == "event") {
-        if (option.getAttribute("data-hasfilter") == "true") {
+		if (option.getAttribute("data-hasfilter") == "true") {
 			if (option.checked == true) {
-			    // Disable events that are not compatible with this event
+				// Disable events that are not compatible with this event
 				disableIncompatibleEventElements(compatibleEventElementIds[option.value]);
-				
+
 				// Enabled relevant filters
 				var filterIds = filterElementIds[option.value];
 				for (var i = 0; i < filterIds.length; i++) {
-				    enableInput(document.getElementById(filterIds[i]));
+					enableInput(document.getElementById(filterIds[i]));
 				}
 			} else { // Event has been unchecked
-			    var compatibleEventIds = compatibleEventElementIds[option.value];
+				var compatibleEventIds = compatibleEventElementIds[option.value];
 				var compatibleEventChecked = false;
-				
+
 				// Check whether any events that are compatible with this one are still checked
 				for (var i = 0; i < compatibleEventIds.length; i++) {
-				    if (document.getElementById(compatibleEventIds[i]).type == "checkbox" && document.getElementById(compatibleEventIds[i]).checked) {
-					    compatibleEventChecked = true;
+					if (document.getElementById(compatibleEventIds[i]).type == "checkbox" && document.getElementById(compatibleEventIds[i]).checked) {
+						compatibleEventChecked = true;
 					}
 				}
-				
+
 				// If no compatible events are checked, enable *all* events and disable filter(s) associated with this event
 				if (!compatibleEventChecked) {
-				    enableEventElementsWithFilters(option);
+					enableEventElementsWithFilters(option);
 					var filterIds = filterElementIds[option.value];
 					for (var i = 0; i < filterIds.length; i++) {
-				        disableInput(document.getElementById(filterIds[i]));
-				    }
+						disableInput(document.getElementById(filterIds[i]));
+					}
 				}
 			}
 		}
 	}
-	
+
 	// If event_throw is checked, automatically check event_systhrow as well
 	if (option.name == "event" && option.value == "throw" && option.checked == true) {
-	    document.getElementById("event_systhrow").checked = true;
+		document.getElementById("event_systhrow").checked = true;
 	}
-	
+
 	// The gpf, traceassert, and abort events cannot trigger a heap dump,
 	// prepare the heap (request=prepwalk), or compact the heap (request=compact)
-    if (heapIncompatibleEventChecked() && !heapCompatibleEventChecked()) { 
-        disableInput(document.getElementById("agent_heap"));
+	if (heapIncompatibleEventChecked() && !heapCompatibleEventChecked()) { 
+		disableInput(document.getElementById("agent_heap"));
 		disableInput(document.getElementById("request_prepwalk"));
 		disableInput(document.getElementById("request_compact"));
-    } else {
-	    enableInput(document.getElementById("agent_heap"));
+	} else {
+		enableInput(document.getElementById("agent_heap"));
 		enableInput(document.getElementById("request_prepwalk"));
 		enableInput(document.getElementById("request_compact"));
-    }
-	
+	}
+
 	// Enable file text input if file option is checked
 	if (option.name == "file") {
-	    if (option.checked == true) {
-	        enableInput(document.getElementById("file_text"));
+		if (option.checked == true) {
+			enableInput(document.getElementById("file_text"));
 			document.getElementById("file_text").focus();
 		} else {
-		    disableInput(document.getElementById("file_text"));
-		}		
+			disableInput(document.getElementById("file_text"));
+		}	
 	}
-	
+
 	// Insert text in the target text input if one of the token buttons is pressed
 	if (option.type == "button" && option.getAttribute("data-target") != null) {
-	    insertText(document.getElementById(option.getAttribute("data-target")), option.getAttribute("data-token"));
+		insertText(document.getElementById(option.getAttribute("data-target")), option.getAttribute("data-token"));
 	}
-	
+
 	// Enable the file option if a compatible agent is checked
 	if (fileCompatibleAgentChecked()) {
-	    enableInput(document.getElementById("file"));
-	    if (document.getElementById("file").checked) {
-		    enableInput(document.getElementById("file_text"));
-	    }
+		enableInput(document.getElementById("file"));
+		if (document.getElementById("file").checked) {
+			enableInput(document.getElementById("file_text"));
+		}
 	} else {
-	    disableInput(document.getElementById("file"));
+		disableInput(document.getElementById("file"));
 		disableInput(document.getElementById("file_text"));	
 	}
-	
+
 	// Remove focus from input element (ensures error styling works correctly)
 	if (option.id != null) {
 		option.blur();
 	}
-	
-    // Build the result string and display it
+
+	// Build the result string and display it
 	buildAndUpdateResult();
 }
 
@@ -328,13 +354,13 @@ function processChange(option) {
 function configureRequestOptions(agent) {
 	var requestsToConfigure = Object.keys(agentsRequiringRequest);
 	for (var i = 0; i < requestsToConfigure.length; i++) {
-	    if (agentNeedsRequest(agent, requestsToConfigure[i])) {
-	        if (document.getElementById("agent_" + agent).checked == true) {
-    	        document.getElementById("request_" + requestsToConfigure[i]).checked = true;
-		    } else if (!enabledAgentsNeedRequest(requestsToConfigure[i])) {
-    		    document.getElementById("request_" + requestsToConfigure[i]).checked = false;
-		    }
-	    }
+		if (agentNeedsRequest(agent, requestsToConfigure[i])) {
+			if (document.getElementById("agent_" + agent).checked == true) {
+				document.getElementById("request_" + requestsToConfigure[i]).checked = true;
+			} else if (!enabledAgentsNeedRequest(requestsToConfigure[i])) {
+				document.getElementById("request_" + requestsToConfigure[i]).checked = false;
+			}
+		}
 	}
 }
 
@@ -355,505 +381,540 @@ function agentNeedsRequest(agent, request) {
 function enabledAgentsNeedRequest(request) {
 	var agentsForRequest = agentsRequiringRequest[request];
 	for (var i = 0; i < agentsForRequest.length; i++) {
-	    if (document.getElementById("agent_" + agentsForRequest[i]).checked) {
-		    return true;
+		if (document.getElementById("agent_" + agentsForRequest[i]).checked) {
+			return true;
 		}	
 	}	
 	return false;    
 }
 
 function heapCompatibleEventChecked() {
-    var section = document.getElementById("event_input");
-    var elements = section.getElementsByTagName("input");
-    for (var i = 0; i < elements.length; i++) {
-	    if (elements[i].checked) {
-	        // This element is checked - check whether it is a heap-compatible event
+	var section = document.getElementById("event_input");
+	var elements = section.getElementsByTagName("input");
+	for (var i = 0; i < elements.length; i++) {
+		if (elements[i].checked) {
+			// This element is checked - check whether it is a heap-compatible event
 			var isCompatibleEvent = true;
 			for (var j = 0; j < noHeapdumpEventElementIds.length; j++) {
-    	        if (elements[i].id == noHeapdumpEventElementIds[j]) {
-	 		        isCompatibleEvent = false;
+				if (elements[i].id == noHeapdumpEventElementIds[j]) {
+					isCompatibleEvent = false;
 				}
 			}
-            if (isCompatibleEvent) {
-			    return true;
+			if (isCompatibleEvent) {
+				return true;
 			}			
-	    }
+		}
 	}
 	// If we reach here, no heap-compatible events were checked
 	return false;
 }
 
 function heapIncompatibleEventChecked() {
-    for (var i = 0; i < noHeapdumpEventElementIds.length; i++) {
-	    if (document.getElementById(noHeapdumpEventElementIds[i]).checked) {
-		    return true;
+	for (var i = 0; i < noHeapdumpEventElementIds.length; i++) {
+		if (document.getElementById(noHeapdumpEventElementIds[i]).checked) {
+			return true;
 		}	
 	}
 	return false;
 }
 
 function fileCompatibleAgentChecked() {
-    for (var i = 0; i < agentsThatDumpAFileIds.length; i++) {
-	    if (document.getElementById(agentsThatDumpAFileIds[i]).checked) {
-		    return true;
+	for (var i = 0; i < agentsThatDumpAFileIds.length; i++) {
+		if (document.getElementById(agentsThatDumpAFileIds[i]).checked) {
+			return true;
 		}
 	}	
 }
 
 function disableIncompatibleEventElements(compatibleEventElementIds) {
-    // need to pass an array so we can deal with throw/systhrow etc.
+	// need to pass an array so we can deal with throw/systhrow etc.
 	var section = document.getElementById("event_input");
-    var elements = section.getElementsByTagName("input");
+	var elements = section.getElementsByTagName("input");
 	for (var i = 0; i < elements.length; i++) {
-	    if (elements[i].getAttribute("data-hasfilter") == "true" || elements[i].type == "text") {
-            var compatible = false;
+		if (elements[i].getAttribute("data-hasfilter") == "true" || elements[i].type == "text") {
+			var compatible = false;
 			for (var j = 0; j < compatibleEventElementIds.length; j++) {
-			    if (elements[i].id == compatibleEventElementIds[j]) {
-				    compatible = true;
+				if (elements[i].id == compatibleEventElementIds[j]) {
+					compatible = true;
 				}
 			}
 			if (!compatible) { 
-			    disableInput(elements[i]);
-		    }
+				disableInput(elements[i]);
+			}
 		}
-    }
+	}
 }
 
 function enableEventElementsWithFilters() {
-    var section = document.getElementById("event_input");
-    var elements = section.getElementsByTagName("input");
+	var section = document.getElementById("event_input");
+	var elements = section.getElementsByTagName("input");
 	for (var i = 0; i < elements.length; i++) {
-	    if (elements[i].type == "checkbox" && elements[i].getAttribute("data-hasfilter") == "true") {
+		if (elements[i].type == "checkbox" && elements[i].getAttribute("data-hasfilter") == "true") {
 			enableInput(elements[i]);
 		}
-    }
+	}
 }
 
 function disableInput(inputElement) {
-    // Disable the input itself
-	inputElement.disabled = true;	
-	
+	// Disable the input itself
+	inputElement.disabled = true;
+
 	// Disable associated labels, if any
 	var labelElements = getLabelsForInput(inputElement);
 	if (typeof labelElements != undefined && labelElements != null) {
 		for (var i = 0; i < labelElements.length; i++) {
-	        labelElements[i].setAttribute("data-disabled", "true");
+			labelElements[i].setAttribute("data-disabled", "true");
 		}
 	}
-	
+
 	// Disable associated buttons, if any
 	var buttonElements = getButtonsForInput(inputElement);
 	if (typeof buttonElements != undefined && buttonElements != null) {
 		for (var i = 0; i < buttonElements.length; i++) {
-	        buttonElements[i].disabled = true;
+			buttonElements[i].disabled = true;
 		}
 	}
 }
 
 function enableInput(inputElement) {
-    // Enable the input itself
+	// Enable the input itself
 	inputElement.disabled = false;
-	
+
 	// Enable associated labels, if any
 	var labelElements = getLabelsForInput(inputElement);
 	if (typeof labelElements != undefined && labelElements != null) {
-	    for (var i = 0; i < labelElements.length; i++) {
-    	    labelElements[i].setAttribute("data-disabled", "false");
+		for (var i = 0; i < labelElements.length; i++) {
+			labelElements[i].setAttribute("data-disabled", "false");
 		}
-    }
-	
+	}
+
 	// Enable associated buttons, if any
 	var buttonElements = getButtonsForInput(inputElement);
 	if (typeof buttonElements != undefined && buttonElements != null) {
 		for (var i = 0; i < buttonElements.length; i++) {
-	        buttonElements[i].disabled = false;
+			buttonElements[i].disabled = false;
 		}
 	}
 }
 
 function getLabelsForInput(inputElement) {
-    var allLabels = document.getElementsByTagName("label");
-    var results = [];
-    for (var i = 0; i < allLabels.length; i++) {
-        if (inputElement.id == allLabels[i].htmlFor) {
-		    results.push(allLabels[i]);
+	var allLabels = document.getElementsByTagName("label");
+	var results = [];
+	for (var i = 0; i < allLabels.length; i++) {
+		if (inputElement.id == allLabels[i].htmlFor) {
+			results.push(allLabels[i]);
 		}
-    }
+	}
 	return results;
 }
 
 function getButtonsForInput(inputElement) {
-    var allInputs = document.getElementsByTagName("input");
-    var results = [];
-    for (var i = 0; i < allInputs.length; i++) {
-        if (allInputs[i].type == "button" && allInputs[i].getAttribute("data-target") == inputElement.id) {
-		    results.push(allInputs[i]);
+	var allInputs = document.getElementsByTagName("input");
+	var results = [];
+	for (var i = 0; i < allInputs.length; i++) {
+		if (allInputs[i].type == "button" && allInputs[i].getAttribute("data-target") == inputElement.id) {
+			results.push(allInputs[i]);
 		}
 	}
 	return results;
 }
 
 function buildAndUpdateResult() {
-    var resultString = "-Xdump:";	
-	
-    var agentString = "";
+	var resultString = "-Xdump:";	
+
+	var agentString = "";
 	var eventString = "";
 	var filterString = "";
-			
-    // Agents
+
+	// Agents
 	var section = document.getElementById("agent_input");
-    var agentElements = section.getElementsByTagName("input");
+	var agentElements = section.getElementsByTagName("input");
 	for (var i = 0; i < agentElements.length; i++) {
-	    if (!agentElements[i].disabled && agentElements[i].checked == true) {
-		    if (agentString != "") {
-			    agentString += "+";
-		    }
-		    agentString += agentElements[i].value;
+		if (!agentElements[i].disabled && agentElements[i].checked == true && agentElements[i].id != "tool_async") {
+			if (agentString != "") {
+				agentString += "+";
+			}
+			agentString += agentElements[i].value;
 		}
 	}
 	if (agentString != "") {
-	    resultString += agentString;
+		resultString += agentString;
 	}
-	
+
 	// Events and filters
 	var eventSection = document.getElementById("event_input");
-    var eventElements = eventSection.getElementsByTagName("input");
-	
+	var eventElements = eventSection.getElementsByTagName("input");
+
 	// Need to make sure filters are only added once for throw/systhrow, load/unload etc.
-    var filterAdded = {};
+	var filterAdded = {};
 	for (var i = 0; i < eventElements.length; i++) {
-	    if (eventElements[i].name != "event") {
-		    // If it's not an event it's a filter - mark it as not added yet
+		if (eventElements[i].name != "event") {
+			// If it's not an event it's a filter - mark it as not added yet
 			filterAdded[eventElements[i]] = false;
 		}
 	}
-	
+
 	for (var i = 0; i < eventElements.length; i++) {
-	    if (eventElements[i].name == "event" && eventElements[i].checked == true) {
+		if (eventElements[i].name == "event" && eventElements[i].checked == true) {
 			if (eventString != "") {
-		        eventString += "+";
-		    }
-		    eventString += eventElements[i].value;
-			
+				eventString += "+";
+			}
+			eventString += eventElements[i].value;
+
 			// Filters
 			if (eventElements[i].getAttribute("data-hasfilter") == "true") {
-			    var filterIds = filterElementIds[eventElements[i].value];
-				
+				var filterIds = filterElementIds[eventElements[i].value];
+
 				for (var j = 0; j < filterIds.length; j++ ) {
-				    var tempString = document.getElementById(filterIds[j]).value;
-					
+					var tempString = document.getElementById(filterIds[j]).value;
+
 					if (tempString == "" || filterAdded[filterIds[j]]) {
-					    // Filter is empty or has already been added
+						// Filter is empty or has already been added
 						continue;					
 					}
-					
+
 					// Get contents of filters and augment/correct if necessary
 					if (filterIds[j] == "event_throwable_class") {
-					    filterString += tempString;
+						filterString += tempString;
 					} else if (filterIds[j] == "event_throwable_method") {
-					    filterString += "#" + tempString;
+						filterString += "#" + tempString;
 					} else if (filterIds[j] == "event_throwable_msg_filter") {
-					    // Do nothing. This is added to the result under a separate flag later on.
-				    } else if (filterIds[j] == "event_throwable_offset") {
-					    if (tempString != "0" && document.getElementById("event_throwable_method").value != "") {
-						    filterString += "#" + tempString;
+						// Do nothing. This is added to the result under a separate flag later on.
+					} else if (filterIds[j] == "event_throwable_offset") {
+						if (tempString != "0" && document.getElementById("event_throwable_method").value != "") {
+							filterString += "#" + tempString;
 						} else {
-                            continue;
-                        }							
+							continue;
+						}							
 					} else if (filterIds[j] == "event_vmstop_filter") {
-					    filterString += "#" + tempString;
+						filterString += "#" + tempString;
 					} else if (filterIds[j] == "event_slow_filter") {
-					    filterString += "#" + tempString + "ms";
+						filterString += "#" + tempString + "ms";
 					} else if (filterIds[j] == "event_allocation_filter_size_min") {
-					    filterString += "#" + tempString;
+						filterString += "#" + tempString;
 					} else if (filterIds[j] == "event_allocation_filter_size_max") {
-					    filterString += ".." + tempString;
+						filterString += ".." + tempString;
 					} else if (filterIds[j] == "event_allocation_filter_units_min" && document.getElementById("event_allocation_filter_size_min").value == "") {
-					    // Don't add units if size is empty
+						// Don't add units if size is empty
 					} else if (filterIds[j] == "event_allocation_filter_units_max" && document.getElementById("event_allocation_filter_size_max").value == "") {
-					    // Don't add units if size is empty
+						// Don't add units if size is empty
 					} else {
-					    // Can add the filter value as-is for all other filters
+						// Can add the filter value as-is for all other filters
 						filterString += tempString;
 					}
-					
+
 					filterAdded[filterIds[j]] = true;
 				}
 			}
-	    }
+		}
 	}
 	if (eventString != "") {
-	    resultString += ":events=" + eventString;
+		resultString += ":events=" + eventString;
 	}
 	if (filterString != "") {
-	    resultString += ",filter=" + filterString;
+		resultString += ",filter=" + filterString;
 	}
-	
+
 	// msg_filter
 	var messageFilterString = document.getElementById("event_throwable_msg_filter").value;
 	if (document.getElementById("event_throwable_msg_filter").disabled == false && messageFilterString != "") {
-	    // Escape quotes in the filter
+		// Escape quotes in the filter
 		messageFilterString = messageFilterString.replace(/"/g, "\\\"");
-			
+
 		// Wrap the command in quotes if the entire option isn't going to be wrapped in quotes
 		if (document.getElementById("wrap_in_quotes").checked) {
-		    resultString += ",msg_filter=" + messageFilterString;
+			resultString += ",msg_filter=" + messageFilterString;
 		} else {
-		    resultString += ",msg_filter=\"" + messageFilterString + "\"";
+			resultString += ",msg_filter=\"" + messageFilterString + "\"";
 		}
 	}
-	
+
 	// range
-	if (document.getElementById("range").checked == true) {
-	    var first = document.getElementById("range_first").value;
-		var last = document.getElementById("range_last").value;
-		resultString += ",range=" + first + ".." + last;
+	var rangeFirst = document.getElementById("range_first").value;
+	var rangeLast = document.getElementById("range_last").value;
+	if (document.getElementById("agent_tool").checked) {
+		// Default with "tool" agent enabled is 1..1
+		if (rangeFirst != 1 || rangeLast != 1) {
+			resultString += ",range=" + rangeFirst + ".." + rangeLast;
+		}
+	} else {
+		// Normal default is 1..0
+		if (rangeFirst != 1 || rangeLast != 0) {
+			resultString += ",range=" + rangeFirst + ".." + rangeLast;
+		}	
 	}
 	
 	// priority
 	if (document.getElementById("priority").checked == true) {
-	    var priority = document.getElementById("priority_value").value;
+		var priority = document.getElementById("priority_value").value;
 		if (priority != "") {
-		    resultString += ",priority=" + priority;
-	    }
+			resultString += ",priority=" + priority;
+		}
 	}
-	
+
 	// exec
 	if (document.getElementById("agent_tool").checked) {
         var execString = document.getElementById("exec").value;
 		if (execString != "") {
-		    // Escape quotes in the command
+			// Escape quotes in the command
 			execString = execString.replace(/"/g, "\\\"");
-			
+
 			// Wrap the command in quotes if the entire option isn't going to be wrapped in quotes
 			if (document.getElementById("wrap_in_quotes").checked) {
-			    resultString += ",exec=" + execString;
+				resultString += ",exec=" + execString;
 			} else {
-			    resultString += ",exec=\"" + execString + "\"";
+				resultString += ",exec=\"" + execString + "\"";
 			}
 		}
-    }
-	
-    // request
+		
+		// opts
+		var optsString = "";
+		var toolAsyncElement = document.getElementById("tool_async");
+		var toolWaitElement = document.getElementById("tool_wait");
+		if (toolAsyncElement.checked) {
+			optsString += toolAsyncElement.value;
+		}
+		if (toolWaitElement.value != 0) {
+			if (optsString != "") {
+				optsString += "+";
+			}
+			optsString += "WAIT" + toolWaitElement.value;
+			}
+		if (optsString != "") {
+			resultString += ",opts=" + optsString;
+		}
+	}
+
+	// request
 	var requestSection = document.getElementById("request_input");
 	var requestElements = requestSection.getElementsByTagName("input");
 	var requestString = "";
 	for (var i = 0; i < requestElements.length; i++) {
-	    if (!requestElements[i].disabled && requestElements[i].checked) {
-		    if (requestElements[i].value != "preempt" || (requestElements[i].value == "preempt" && document.getElementById("agent_java").checked == true)) {
-			    if (requestString != "") {
-    		        requestString += "+";
-		        }
-			    requestString += requestElements[i].value;
-		    }
-	    }
-	}
-	if (requestString != "") {
-	    resultString += ",request=" + requestString;
-	}
-	
-	// Dump file name
-	if (document.getElementById("file").checked && !document.getElementById("file").disabled) {
-        resultString += ",file=";
-		var fileString = document.getElementById("file_text").value;
-		if (fileString != "") {
-		    // Escape quotes in the filename
-			// (I'm not sure what sort of monster would put quotes in the filename, but hey)
-			fileString = fileString.replace(/"/g, "\\\"");
-			
-			// Wrap the filename in quotes if the entire option isn't going to be wrapped in quotes
-			if (document.getElementById("wrap_in_quotes").checked) {
-			    resultString += fileString;
-			} else {
-			    resultString += "\"" + fileString + "\"";
+		if (!requestElements[i].disabled && requestElements[i].checked) {
+			if (requestElements[i].value != "preempt" || (requestElements[i].value == "preempt" && document.getElementById("agent_java").checked == true)) {
+				if (requestString != "") {
+					requestString += "+";
+				}
+				requestString += requestElements[i].value;
 			}
 		}
-    }
-	
+	}
+	if (requestString != "") {
+		resultString += ",request=" + requestString;
+	}
+
+	// Dump file name
+	if (document.getElementById("file").checked && !document.getElementById("file").disabled) {
+		resultString += ",file=";
+		var fileString = document.getElementById("file_text").value;
+		if (fileString != "") {
+			// Escape quotes in the filename
+			// (I'm not sure what sort of monster would put quotes in the filename, but hey)
+			fileString = fileString.replace(/"/g, "\\\"");
+
+			// Wrap the filename in quotes if the entire option isn't going to be wrapped in quotes
+			if (document.getElementById("wrap_in_quotes").checked) {
+				resultString += fileString;
+			} else {
+				resultString += "\"" + fileString + "\"";
+			}
+		}
+	}
+
 	// Wrap in quotes if option checked
 	if (document.getElementById("wrap_in_quotes").checked) {
-	    resultString = "\"" + resultString + "\"";
+		resultString = "\"" + resultString + "\"";
 	}
-	
+
 	// Escape HTML characters
 	resultString = escapeHTML(resultString);
-	
+
 	// Add <wbr> tags after '+', ','. '/' and '=' characters
 	// to make the wrapping prettier for longer options
 	resultString = resultString.replace(/,/g, ",<wbr>");
 	resultString = resultString.replace(/\+/g, "+<wbr>");
 	resultString = resultString.replace(/\//g, "/<wbr>");
 	resultString = resultString.replace(/=/g, "=<wbr>");
-	
+
 	// Rudimentry checks for validity of result
 	var resultIsGreen = true;
 	var errorsHtml = "";
 	var warningsHtml = "";
-	
+
 	// Check whether any dump events are selected
 	if (eventString == "") {
-	    resultIsGreen = false;
+		resultIsGreen = false;
 		errorsHtml += "ERROR: No dump event selected<br>";		
 	}
-	
+
 	// Check whether any dump agents are selected
 	if (agentString == "") {
-	    resultIsGreen = false;
+		resultIsGreen = false;
 		errorsHtml += "ERROR: No dump agent selected<br>";		
 	}
-	
+
 	// Check object allocation filter sizes
 	var minimumSizeElement = document.getElementById("event_allocation_filter_size_min");
 	var maximumSizeElement = document.getElementById("event_allocation_filter_size_max");
 	if (document.getElementById("event_allocation").checked) {
-        if (minimumSizeElement.value == "" || minimumSizeElement.value < 0 || minimumSizeElement.value > maximumSizeElement.value) {
-	        resultIsGreen = false;
-	        setErrorStyle(minimumSizeElement);
-	        errorsHtml += "ERROR: Invalid minimum size for object allocation size filter: must be >= 0, and must be < maximum size<br>";		
-	    } else {
-	        unsetErrorStyle(minimumSizeElement);
-	    }
-		
+		if (minimumSizeElement.value == "" || minimumSizeElement.value < 0 || minimumSizeElement.value > maximumSizeElement.value) {
+			resultIsGreen = false;
+			setErrorStyle(minimumSizeElement);
+			errorsHtml += "ERROR: Invalid minimum size for object allocation size filter: must be >= 0, and must be < maximum size<br>";		
+		} else {
+			unsetErrorStyle(minimumSizeElement);
+		}
+
 		if (maximumSizeElement.value == "" || maximumSizeElement.value <= 0 || minimumSizeElement.value > maximumSizeElement.value) {
-	        resultIsGreen = false;
-	        setErrorStyle(maximumSizeElement);
-	        errorsHtml += "ERROR: Invalid maximum size for object allocation size filter: must be > 0, and must be > minimum size<br>";		
-	    } else {
-	        unsetErrorStyle(maximumSizeElement);
-	    }
+			resultIsGreen = false;
+			setErrorStyle(maximumSizeElement);
+			errorsHtml += "ERROR: Invalid maximum size for object allocation size filter: must be > 0, and must be > minimum size<br>";		
+		} else {
+			unsetErrorStyle(maximumSizeElement);
+		}
 	} else {
-	    // Ensure error styling is removed if this option is unchecked
+		// Ensure error styling is removed if this option is unchecked
 		unsetErrorStyle(minimumSizeElement);
 		unsetErrorStyle(maximumSizeElement);
 	}
-	
+
 	// Check that a command has been specified if the tool agent is selected
-    var execElement = document.getElementById("exec");
+	var execElement = document.getElementById("exec");
 	if (document.getElementById("agent_tool").checked && execElement.value == "") {
-	    resultIsGreen = false;
+		resultIsGreen = false;
 		setErrorStyle(execElement);
 		errorsHtml += "ERROR: Shell command (tool) agent is checked, but no shell command has been specified<br>";		
 	} else {
-	    unsetErrorStyle(execElement);
+		unsetErrorStyle(execElement);
 	}
 	
+	// Check value provided for tool wait time
+	var toolWaitElement = document.getElementById("tool_wait");
+	if (!toolWaitElement.disabled && toolWaitElement.value < 0) {
+		resultIsGreen = false;
+		setErrorStyle(toolWaitElement);
+		errorsHtml += "ERROR: Invalid tool wait time: must be > 0<br>";
+	} else {
+		unsetErrorStyle(toolWaitElement);
+	}
+
 	// Check validity of the throwable class string
 	var throwableClassElement = document.getElementById("event_throwable_class")
 	if (!throwableClassElement.disabled) {
-	    var classValue = throwableClassElement.value;
+		var classValue = throwableClassElement.value;
 		if (classValue.lastIndexOf("*") > 0) {
-		    if (classValue.lastIndexOf("*") != (classValue.length - 1)) {
-    	        // Wildcard must be placed at the beginning and/or end of the string
-		        resultIsGreen = false;
-		        setErrorStyle(throwableClassElement);
-		        errorsHtml += "ERROR: Exception class filter wildcards can only be used at the beginning and/or end of the filter<br>";
-		    } else if (document.getElementById("event_throwable_method").value != "") {
-    	        // Wildcard not allowed at the end of the string if a method filter is enabled
-		        resultIsGreen = false;
-		        setErrorStyle(throwableClassElement);
-		        errorsHtml += "ERROR: Exception class filter must not end with a wildcard when a method filter is specified<br>";
-		    } else {
-    		    // Wildcard looks ok
-    	        unsetErrorStyle(throwableClassElement);
-		    }
+			if (classValue.lastIndexOf("*") != (classValue.length - 1)) {
+				// Wildcard must be placed at the beginning and/or end of the string
+				resultIsGreen = false;
+				setErrorStyle(throwableClassElement);
+				errorsHtml += "ERROR: Exception class filter wildcards can only be used at the beginning and/or end of the filter<br>";
+			} else if (document.getElementById("event_throwable_method").value != "") {
+				// Wildcard not allowed at the end of the string if a method filter is enabled
+				resultIsGreen = false;
+				setErrorStyle(throwableClassElement);
+				errorsHtml += "ERROR: Exception class filter must not end with a wildcard when a method filter is specified<br>";
+			} else {
+				// Wildcard looks ok
+				unsetErrorStyle(throwableClassElement);
+			}
 		} else {
-		    // No wildcard, or a single wildcard at the beginning of the string
+			// No wildcard, or a single wildcard at the beginning of the string
 			// Note: A filter containing just a wildcard (i.e. "*") is also fine
-		    unsetErrorStyle(throwableClassElement);
+			unsetErrorStyle(throwableClassElement);
 		}		
 	}
 
-    // Check validity of any wildcard in the throwable method string	
+	// Check validity of any wildcard in the throwable method string	
 	var throwableMethodElement = document.getElementById("event_throwable_method");
 	if (!throwableMethodElement.disabled) {
-	    var methodValue = throwableMethodElement.value;
+		var methodValue = throwableMethodElement.value;
 		if (methodValue.indexOf("*") != -1) {
-            if (document.getElementById("event_throwable_offset").value != "0") {
-    		    // No wildcard allowed if using stack offset
+			if (document.getElementById("event_throwable_offset").value != "0") {
+				// No wildcard allowed if using stack offset
 				resultIsGreen = false;
-			    setErrorStyle(throwableMethodElement);
-			    errorsHtml += "ERROR: Exception method filter must not contain a wildcard when using a stack offset.<br>";
-		    } else if (methodValue.indexOf("*") != (methodValue.length - 1)) {
-    		    // If no stack offset, wildcard must be placed at the end
+				setErrorStyle(throwableMethodElement);
+				errorsHtml += "ERROR: Exception method filter must not contain a wildcard when using a stack offset.<br>";
+			} else if (methodValue.indexOf("*") != (methodValue.length - 1)) {
+				// If no stack offset, wildcard must be placed at the end
 				resultIsGreen = false;
-			    setErrorStyle(throwableMethodElement);
-			    errorsHtml += "ERROR: Exception method filter wildcard can only be used at the end of the filter<br>";
-		    } else {
-		        // Wildcard looks ok
+				setErrorStyle(throwableMethodElement);
+				errorsHtml += "ERROR: Exception method filter wildcard can only be used at the end of the filter<br>";
+			} else {
+				// Wildcard looks ok
 				unsetErrorStyle(throwableMethodElement);
-		    }
+			}
 		} else {
-		    // No wildcard
-		    unsetErrorStyle(throwableMethodElement);
+			// No wildcard
+			unsetErrorStyle(throwableMethodElement);
 		}
 	}
-	
+
 	// Check that a priority has been specified if the dump priority option is selected
-    var priorityValueElement = document.getElementById("priority_value");
+	var priorityValueElement = document.getElementById("priority_value");
 	if (document.getElementById("priority").checked && priorityValueElement.value == "") {
-	    resultIsGreen = false;
+		resultIsGreen = false;
 		setErrorStyle(priorityValueElement);
 		errorsHtml += "ERROR: Dump priority option is checked, but no priority value has been specified<br>";		
 	} else {
-	    unsetErrorStyle(priorityValueElement);
+		unsetErrorStyle(priorityValueElement);
 	}
-	
+
 	// Dump filename checks
-    var dumpFileElement = document.getElementById("file_text");
+	var dumpFileElement = document.getElementById("file_text");
 	if (document.getElementById("file").checked) {
-	    if (dumpFileElement.value == "") {
-		    resultIsGreen = false;
-		    setErrorStyle(priorityValueElement);
-		    errorsHtml += "ERROR: Dump file option is checked, but no file name has been specified<br>";
+		if (dumpFileElement.value == "") {
+			resultIsGreen = false;
+			setErrorStyle(priorityValueElement);
+			errorsHtml += "ERROR: Dump file option is checked, but no file name has been specified<br>";
 		} else {
-		    unsetErrorStyle(priorityValueElement);
+			unsetErrorStyle(priorityValueElement);
 		}
-		
+
 		if (containsReservedChars(dumpFileElement.value)) {
-		    warningsHtml += "WARNING: Dump file name contains a character that is disallowed on some platforms<br>";		
+			warningsHtml += "WARNING: Dump file name contains a character that is disallowed on some platforms<br>";		
 		}		
 	} else {
-	    unsetErrorStyle(priorityValueElement);
+		unsetErrorStyle(priorityValueElement);
 	}
-	
+
 	// Check the dump priority value
 	if (document.getElementById("priority").checked && (priorityValueElement.value < 0 || priorityValueElement.value > 999)) {
-	    resultIsGreen = false;
+		resultIsGreen = false;
 		setErrorStyle(priorityValueElement);
 		errorsHtml += "ERROR: Invalid dump priority value: must be > 0 and < 999<br>";		
 	} else {
-	    unsetErrorStyle(priorityValueElement);
+		unsetErrorStyle(priorityValueElement);
 	}
-	
+
 	// Check whether any incompatible events/agents are selected
 	// (nearly all incompatible scenarios are prevented by enabling/disabling input fields)
 	if (heapIncompatibleEventChecked()) {
-	    if (!document.getElementById("agent_heap").disabled && document.getElementById("agent_heap").checked) {
-		    warningsHtml += "WARNING: The PHD heap dump agent cannot be triggered by GPF, abort, or internal JVM error events<br>";
+		if (!document.getElementById("agent_heap").disabled && document.getElementById("agent_heap").checked) {
+			warningsHtml += "WARNING: The PHD heap dump agent cannot be triggered by GPF, abort, or internal JVM error events<br>";
 		}
 		if (!document.getElementById("request_prepwalk").disabled && document.getElementById("request_prepwalk").checked) {
-		    warningsHtml += "WARNING: Dump agents triggered by a GPF, abort, or internal JVM error cannot ensure the heap is walkable prior to dumping<br>";
+			warningsHtml += "WARNING: Dump agents triggered by a GPF, abort, or internal JVM error cannot ensure the heap is walkable prior to dumping<br>";
 		}
 		if (!document.getElementById("request_compact").disabled && document.getElementById("request_compact").checked) {
-		    warningsHtml += "WARNING: Dump agents triggered by a GPF, abort, or internal JVM error cannot conduct a global GC prior to dumping<br>";
+			warningsHtml += "WARNING: Dump agents triggered by a GPF, abort, or internal JVM error cannot conduct a global GC prior to dumping<br>";
 		}
 		if (!document.getElementById("request_exclusive").disabled && document.getElementById("request_exclusive").checked) {
-		    warningsHtml += "WARNING: Dump agents triggered by a GPF, abort, or internal JVM error may have problems obtaining exclusive JVM access<br>";
+			warningsHtml += "WARNING: Dump agents triggered by a GPF, abort, or internal JVM error may have problems obtaining exclusive JVM access<br>";
 		}		
 	}
-	
+
 	// Add the result string in the appropriate colour
 	if (resultIsGreen) {
-	    document.getElementById("result").innerHTML = "<font color=\"green\">" + resultString + "</font>";
+		document.getElementById("result").innerHTML = "<font color=\"green\">" + resultString + "</font>";
 	} else {
 		document.getElementById("result").innerHTML = "<font color=\"red\">" + resultString + "</font>";
 	}
-	
+
 	// Add errors/warnings, if any
 	if (errorsHtml != "" || warningsHtml != "") { 
-	    document.getElementById("errors").innerHTML = errorsHtml + warningsHtml;
+		document.getElementById("errors").innerHTML = errorsHtml + warningsHtml;
 	} else {
-	    document.getElementById("errors").innerHTML = "&nbsp;";
+		document.getElementById("errors").innerHTML = "&nbsp;";
 	}
 }
 
@@ -861,97 +922,97 @@ function buildAndUpdateResult() {
 // Otherwise return false
 function containsReservedChars(string) {
 	if (   string.indexOf("\\") != -1
-		|| string.indexOf("/") != -1
-		|| string.indexOf(":") != -1
-		|| string.indexOf("*") != -1
-		|| string.indexOf("?") != -1
-		|| string.indexOf("\"") != -1
-		|| string.indexOf("<") != -1
-		|| string.indexOf(">") != -1
-		|| string.indexOf("|") != -1
+	    || string.indexOf("/") != -1
+	    || string.indexOf(":") != -1
+	    || string.indexOf("*") != -1
+	    || string.indexOf("?") != -1
+	    || string.indexOf("\"") != -1
+	    || string.indexOf("<") != -1
+	    || string.indexOf(">") != -1
+	    || string.indexOf("|") != -1
 	) {
-	    return true;
+		return true;
 	} else {
-	    return false;
+		return false;
 	}	
 }
 
 function setErrorStyle(inputElement) {
-    // Only set the error style if this element doesn't have focus.
+	// Only set the error style if this element doesn't have focus.
 	if (document.activeElement != inputElement) {
 		inputElement.style.borderColor = "red";
-	    inputElement.style.borderStyle = "solid";
+		inputElement.style.borderStyle = "solid";
 	}
 }
 
 function unsetErrorStyle(inputElement) {
-    inputElement.style.borderColor = "";
+	inputElement.style.borderColor = "";
 	inputElement.style.borderStyle = "";
-	
+
 	inputElement.style.borderColor = null;
 	inputElement.style.borderStyle = null;
 }
 
 function escapeHTML(text) {
-    return text.replace(/&/g, "&amp;")
-               .replace(/</g, "&lt;")
-               .replace(/>/g, "&gt;")
-               .replace(/"/g, "&quot;")
-               .replace(/'/g, "&#039;");
+	return text.replace(/&/g, "&amp;")
+	           .replace(/</g, "&lt;")
+	           .replace(/>/g, "&gt;")
+	           .replace(/"/g, "&quot;")
+	           .replace(/'/g, "&#039;");
 }
 
 // If a string ends with a '&' remove it
 function removeFinalAmpersandIfPresent(string) {
-    if (string.length > 0 && string.lastIndexOf("&") == string.length - 1) {
-	    return string.slice(0, -1);
+	if (string.length > 0 && string.lastIndexOf("&") == string.length - 1) {
+		return string.slice(0, -1);
 	} else {
-	    return string;
+		return string;
 	}
 }
 
 // Inserts text in a target text input, replacing the current selected text
 function insertText(targetElement, textToInsert) {
-    var oldTextValue = targetElement.value;
+	var oldTextValue = targetElement.value;
 	var selectionStart = targetElement.selectionStart;
 	var selectionEnd = targetElement.selectionEnd;
-    
+
 	// Get text before/after current selection
 	var textBeforeSelection = oldTextValue.substring(0, selectionStart);
 	var textAfterSelection = oldTextValue.substring(selectionEnd, oldTextValue.length);
-	
+
 	// Insert text, effectively replacing the current selection
-    targetElement.value = textBeforeSelection + textToInsert + textAfterSelection;
-    
+	targetElement.value = textBeforeSelection + textToInsert + textAfterSelection;
+
 	// Set cursor position to the end of the inserted text
 	var cursorPosition = selectionStart + textToInsert.length;
-    
+
 	// Make sure nothing is selected
 	targetElement.selectionStart = cursorPosition;
-    targetElement.selectionEnd = cursorPosition;
-    
+	targetElement.selectionEnd = cursorPosition;
+
 	// Give focus to the target field
 	targetElement.focus();
 }
 
 function copyTextToClipboard(element) {
-    var selection = window.getSelection(); // get the window's Selection object
-    selection.removeAllRanges(); // deselect any user selected text
-	
+	var selection = window.getSelection(); // get the window's Selection object
+	selection.removeAllRanges(); // deselect any user selected text
+
 	// Create a temporary element and store the target element's text in it
 	// (while stripping out any HTML tags)
 	var tempElement = document.createElement("p");
-	tempElement.innerHTML = element.innerText;
-	
+	tempElement.innerText = element.innerText;
+
 	// Append temporary element to the DOM so we can copy its contents
-    document.body.appendChild(tempElement);
-	
+	document.body.appendChild(tempElement);
+
 	var range = document.createRange(); // create a new range object
-    range.selectNodeContents(tempElement); // set range to cover target element text
-    selection.addRange(range); // add range to Selection object
-	
+	range.selectNodeContents(tempElement); // set range to cover target element text
+	selection.addRange(range); // add range to Selection object
+
 	document.execCommand("copy"); // do the copy
 	selection.removeAllRanges(); // deselect the target element's text
-	
+
 	// Remove the temporary text area
 	tempElement.parentNode.removeChild(tempElement);
 }
@@ -961,40 +1022,40 @@ function copyLinkToClipboard() {
 	var serializedForm = "";
 	var inputs = document.getElementById("XdumpForm").getElementsByTagName("input");
 	for (var i = 0; i < inputs.length; i++) {
-	    var inputElement = inputs[i];
+		var inputElement = inputs[i];
 		if (inputElement.type == "checkbox") {
-		    if (inputElement.checked) {
+			if (inputElement.checked) {
 				serializedForm += inputElement.id + "=1&";
 			} else if (inputElement.id == "request_exclusive" || inputElement.id == "request_prepwalk") {
-			    // These are checked by default, so if they're unchecked we need to make note.
+				// These are checked by default, so if they're unchecked we need to make note.
 				serializedForm += inputElement.id + "=0&";
 			}			
 		}
 		if (inputElement.type == "text" && inputElement.value != "") {
-		    serializedForm += inputElement.id + "=" + encodeURIComponent(inputElement.value) + "&";		    
+			serializedForm += inputElement.id + "=" + encodeURIComponent(inputElement.value) + "&";		    
 		}
 		if (inputElement.type == "number") {
-		    serializedForm += inputElement.id + "=" + inputElement.value + "&";		    
+			serializedForm += inputElement.id + "=" + inputElement.value + "&";		    
 		}	
 	}	
 	serializedForm = removeFinalAmpersandIfPresent(serializedForm);
-	
+
 	// Get the base URL
 	var urlString = window.location.protocol + '//' + window.location.host + window.location.pathname;
-		
+
 	// Append the serialized form
 	urlString += "?" + serializedForm;
-	
+
 	// Create a temporary element and store the URL in it
 	var tempElement = document.createElement("p");
 	tempElement.innerHTML = urlString;
-	
+
 	// Append temporary element to the DOM so we can copy its contents
-    document.body.appendChild(tempElement);
-	
+	document.body.appendChild(tempElement);
+
 	// Copy to the clipboard
 	copyTextToClipboard(tempElement);
-	
+
 	// Remove the temporary text area
 	tempElement.parentNode.removeChild(tempElement);
 }
@@ -1003,14 +1064,14 @@ function copyLinkToClipboard() {
 function clearAndReload() {
 	if (confirm("Are you sure you want to set all options to default values?")) {
 		location.replace(window.location.pathname);	
-    } else {
-        // Do nothing
-    }
+	} else {
+		// Do nothing
+	}
 }
 
 // This is the alternative action to submitting the form when the user presses return in a text field
 function handleSubmit() {
-    processChange();
+	processChange();
 	return false;
 }
 
@@ -1018,61 +1079,61 @@ function handleSubmit() {
 
 <style> 
 body {
-    font-family: verdana;
-    font-size: 10pt;
+	font-family: verdana;
+	font-size: 10pt;
 }
 
 table {
-    font-size: 10pt;
+	font-size: 10pt;
 }
 
 button {
-    font-size: 10pt;
+	font-size: 10pt;
 }
 
 label {
-    vertical-align: middle;
+	vertical-align: middle;
 }
 
 input {
-    vertical-align: middle;
+	vertical-align: middle;
 }
 
 input[type=text] {
-    padding: 2px 2px;
+	padding: 2px 2px;
 	box-sizing: border-box;
 }
 
 input[type=number] {
-    width: 70px;
+	width: 70px;
 	padding: 2px 2px;
-    box-sizing: border-box;
+	box-sizing: border-box;
 }
 
 select {
-    padding: 2px 2px;
-    box-sizing: border-box;
+	padding: 2px 2px;
+	box-sizing: border-box;
 	vertical-align: middle;
 }
 
 li {
-    padding: 1px 0px;
+	padding: 1px 0px;
 }
 
 label[data-disabled=true] {
-    color: #ccc;
+	color: #ccc;
 }
 
 label[data-disabled=false] {
-    color: #000;
+	color: #000;
 }
 
 td {
-    vertical-align: top;
+	vertical-align: top;
 }
 
 ul {
-    list-style-type: none;
+	list-style-type: none;
 	padding: 0;
 }
 
@@ -1088,331 +1149,332 @@ ul {
 
 <table border="0" cellspacing="0" cellpadding="4" style="width:1100px; table-layout:fixed">
 <tr>
-    <td  class="head1" colspan="2">
-        OpenJ9: Xdump Option Builder
-    </td>
+	<td  class="head1" colspan="2">
+	OpenJ9: Xdump Option Builder
+	</td>
 </tr>
 
 <tr>
-    <td rowspan="2">	
-        <b style="font-size: 12pt">Dump Events</b>
-        <ul id="event_input">
-            <hr>
-            <li>
-	            <input type="checkbox" id="event_user"         name="event" value="user"        onchange="processChange(this)" data-hasfilter="false">
-		        <label for="event_user">User signal i.e. SIGQUIT ("kill -3") / SIGBREAK</label>
-	        </li>
-            <li>
-	            <input type="checkbox" id="event_gpf"          name="event" value="gpf"         onchange="processChange(this)" data-hasfilter="false">
-		        <label for="event_gpf">General Protection Fault (GPF) or unexpected SIGSEGV</label>
-            </li>
-			<li>
-	            <input type="checkbox" id="event_abort"        name="event" value="abort"       onchange="processChange(this)" data-hasfilter="false">
-		        <label for="event_abort">Process abort i.e. SIGABRT</label>
-	        </li> 
-            <li>
-	            <input type="checkbox" id="event_traceassert"  name="event" value="traceassert" onchange="processChange(this)" data-hasfilter="false">
-		        <label for="event_traceassert">Internal JVM error (assertion failure)</label>
-	        </li>
-	        <li>
-	            <input type="checkbox" id="event_corruptcache" name="event" value="corruptcache"onchange="processChange(this)" data-hasfilter="false">
-		        <label for="event_corruptcache">Corrupt shared classes cache</label>
-	        </li>
-	        <li>
-	            <input type="checkbox" id="event_excessivegc"  name="event" value="excessivegc" onchange="processChange(this)" data-hasfilter="false">
-		        <label for="event_excessivegc">Excessive GC activity</label>
-	        </li>
-	        <li>
-	            <input type="checkbox" id="event_fullgc"       name="event" value="fullgc"      onchange="processChange(this)" data-hasfilter="false">
-		        <label for="event_fullgc">Global GC</label>
-	        </li>
-	        <li>
-	            <input type="checkbox" id="event_vmstart"      name="event" value="vmstart"     onchange="processChange(this)" data-hasfilter="false">
-		        <label for="event_vmstart">VM startup</label>
-	        </li>
-            <li>
-	            <input type="checkbox" id="event_vmstop"       name="event" value="vmstop"      onchange="processChange(this)" data-hasfilter="true">
-		        <label for="event_vmstop">VM shutdown. Exit code:</label> 
-	            <input type="number" id="event_vmstop_filter" name="vmstop_text" min="-9999" max="9999" value="" disabled onchange="processChange(this)" onBlur="processChange(this)">
-	        </li>
-	        <li>
-	            <input type="checkbox" id="event_thrstart"     name="event" value="thrstart"    onchange="processChange(this)" data-hasfilter="false">
-		        <label for="event_thrstart">Thread started</label>
-	        </li>
-			<li>
-	            <input type="checkbox" id="event_thrstop"     name="event" value="thrstop"    onchange="processChange(this)" data-hasfilter="false">
-		        <label for="event_thrstop">Thread stopped</label>
-	        </li>
-			<li>
-	            <input type="checkbox" id="event_blocked"     name="event" value="blocked"    onchange="processChange(this)" data-hasfilter="false">
-		        <label for="event_blocked">Thread blocked</label>
-	        </li>
-	        <li>
-        	    <input type="checkbox" id="event_slow"         name="event" value="slow"        onchange="processChange(this)" data-hasfilter="true">
-        		<label for="event_slow">Thread slow/hung. Unresponsive threshold in ms:</label>
-        	    <input type="number" id="event_slow_filter" name="slow_ms" size="2" value = "50" min="1" max="9999" disabled onchange="processChange(this)" onBlur="processChange(this)">
-	        </li>
+	<td rowspan="2">	
+		<b style="font-size: 12pt">Dump Events</b>
+		<ul id="event_input">
 			<hr>
-	        <li>
-        	    <input type="checkbox" id="event_allocation"   name="event" value="allocation"  onchange="processChange(this)" data-hasfilter="true">
-        		<label for="event_allocation">Object allocated</label>
-        	    <br>
-		        <table>
-		            <tr>
-		                <td>
-		                    <label data-disabled="true" for="event_allocation_filter_size_min">Minimum size:</label>
-	                    </td>		        
-				        <td>
-        				    <input type="number" id="event_allocation_filter_size_min" name="event_allocation_filter_size_min" min="1" max="9999" value="256" disabled onchange="processChange(this)" onBlur="processChange(this)">
-                	        <select id="event_allocation_filter_units_min" name="event_allocation_filter_units_min" size="1" disabled onchange="processChange(this)">
-                                <option value=""> bytes </option>
- 			                    <option value="k" selected> kilobytes</option>
-                                <option value="m"> megabytes </option>
-                            </select>
-			            </td>
-		            </tr>
-	                <tr>
-		                <td>
-		                    <label data-disabled="true" for="event_allocation_filter_size_max">Maximum size:</label>
-		                </td>
-				        <td>
-				            <input type="number" id="event_allocation_filter_size_max" name="event_allocation_filter_size_max" min="1" max="9999" value="512" disabled onchange="processChange(this)" onBlur="processChange(this)">
-		        	        <select id="event_allocation_filter_units_max" name="event_allocation_filter_units_max" size="1" disabled onchange="processChange(this)">
-                                <option value=""> bytes </option>
-			                    <option value="k" selected> kilobytes</option>
-                                <option value="m"> megabytes </option>
-                            </select>
-		                </td>
-		            </tr>
-        		</table>
-	        </li>
-	
-	        <hr>
-        	<li>
-	            <input type="checkbox" id="event_throw"        name="event" value="throw"       onchange="processChange(this)" data-hasfilter="true">
-		        <label for="event_throw">Exception thrown by Java code</label>
-            </li>
-	        <li>
-	            <input type="checkbox" id="event_systhrow"     name="event" value="systhrow"    onchange="processChange(this)" data-hasfilter="true">
-		        <label for="event_systhrow">Exception thrown by JVM internals</label>
-	        </li>
-            <li>
-	            <input type="checkbox" id="event_catch"        name="event" value="catch"       onchange="processChange(this)" data-hasfilter="true">
-		        <label for="event_catch">Exception caught</label>
-            </li>
-            <li>
-	            <input type="checkbox" id="event_uncaught"     name="event" value="uncaught"    onchange="processChange(this)" data-hasfilter="true">
-		        <label for="event_uncaught">Exception uncaught</label>
-                <table>
-		            <tr>
-    		            <td><label data-disabled="true" for="event_throwable_class">Exception class name:</label></td>
-		                <td><input style="width: 325px" type="text" id="event_throwable_class" name="throwable_class" size="41" value="" disabled onchange="processChange(this)" onBlur="processChange(this)"></td>
-		            </tr>
-		            <tr>
-    		            <td><label data-disabled="true" for="event_throwable_method">Method name / offset:</label></td>
-                        <td nowrap>
-							<input style="width: 250px" type="text" id="event_throwable_method" name="throwable_method" size="30" value="" disabled onchange="processChange(this)" onBlur="processChange(this)">
-				            <input type="number" id="event_throwable_offset" name="range_first" min="0" max="999" value="0" size="4" disabled onchange="processChange(this)" onBlur="processChange(this)" onBlur="processChange(this)">
-						</td>
-		            </tr>
+			<li>
+				<input type="checkbox" id="event_user"         name="event" value="user"        onchange="processChange(this)" data-hasfilter="false">
+				<label for="event_user">User signal i.e. SIGQUIT ("kill -3") / SIGBREAK</label>
+			</li>
+			<li>
+				<input type="checkbox" id="event_gpf"          name="event" value="gpf"         onchange="processChange(this)" data-hasfilter="false">
+				<label for="event_gpf">General Protection Fault (GPF) or unexpected SIGSEGV</label>
+			</li>
+			<li>
+				<input type="checkbox" id="event_abort"        name="event" value="abort"       onchange="processChange(this)" data-hasfilter="false">
+				<label for="event_abort">Process abort i.e. SIGABRT</label>
+			</li> 
+			<li>
+				<input type="checkbox" id="event_traceassert"  name="event" value="traceassert" onchange="processChange(this)" data-hasfilter="false">
+				<label for="event_traceassert">Internal JVM error (assertion failure)</label>
+			</li>
+			<li>
+				<input type="checkbox" id="event_corruptcache" name="event" value="corruptcache"onchange="processChange(this)" data-hasfilter="false">
+				<label for="event_corruptcache">Corrupt shared classes cache</label>
+			</li>
+			<li>
+				<input type="checkbox" id="event_excessivegc"  name="event" value="excessivegc" onchange="processChange(this)" data-hasfilter="false">
+				<label for="event_excessivegc">Excessive GC activity</label>
+			</li>
+			<li>
+				<input type="checkbox" id="event_fullgc"       name="event" value="fullgc"      onchange="processChange(this)" data-hasfilter="false">
+				<label for="event_fullgc">Global GC</label>
+			</li>
+			<li>
+				<input type="checkbox" id="event_vmstart"      name="event" value="vmstart"     onchange="processChange(this)" data-hasfilter="false">
+				<label for="event_vmstart">VM startup</label>
+			</li>
+			<li>
+				<input type="checkbox" id="event_vmstop"       name="event" value="vmstop"      onchange="processChange(this)" data-hasfilter="true">
+				<label for="event_vmstop">VM shutdown. Exit code:</label> 
+				<input type="number" id="event_vmstop_filter" name="vmstop_text" min="-9999" max="9999" value="" disabled onchange="processChange(this)" onBlur="processChange(this)">
+			</li>
+			<li>
+				<input type="checkbox" id="event_thrstart"     name="event" value="thrstart"    onchange="processChange(this)" data-hasfilter="false">
+				<label for="event_thrstart">Thread started</label>
+			</li>
+			<li>
+				<input type="checkbox" id="event_thrstop"     name="event" value="thrstop"    onchange="processChange(this)" data-hasfilter="false">
+				<label for="event_thrstop">Thread stopped</label>
+			</li>
+			<li>
+				<input type="checkbox" id="event_blocked"     name="event" value="blocked"    onchange="processChange(this)" data-hasfilter="false">
+				<label for="event_blocked">Thread blocked</label>
+			</li>
+			<li>
+				<input type="checkbox" id="event_slow"         name="event" value="slow"        onchange="processChange(this)" data-hasfilter="true">
+				<label for="event_slow">Thread slow/hung. Unresponsive threshold in ms:</label>
+				<input type="number" id="event_slow_filter" name="slow_ms" size="2" value = "50" min="1" max="9999" disabled onchange="processChange(this)" onBlur="processChange(this)">
+			</li>
+			<hr>
+			<li>
+				<input type="checkbox" id="event_allocation"   name="event" value="allocation"  onchange="processChange(this)" data-hasfilter="true">
+				<label for="event_allocation">Object allocated</label>
+				<br>
+				<table>
 					<tr>
-    			        <td><label data-disabled="true" for="event_throwable_msg_filter">Exception message (Java 8+):</label></td>
-		                <td><input style="width: 325px" type="text" id="event_throwable_msg_filter" name="throwable_message" size="41" value="" disabled onchange="processChange(this)" onBlur="processChange(this)"></td>
-	                </tr>
-        		</table>
-        	</li>
-	
-	        <hr>
-	        <li>
-	            <input type="checkbox" id="event_load"         name="event" value="load"        onchange="processChange(this)" data-hasfilter="true">
-		        <label for="event_load">Class loaded</label>
-	        </li>
-            <li>
-	            <input type="checkbox" id="event_unload"       name="event" value="unload"      onchange="processChange(this)" data-hasfilter="true">
-		        <label for="event_unload">Class unloaded</label><br>
-		        <label data-disabled="true" for="event_class_filter">Class name:</label> <input style="width: 450px" type="text" id="event_class_filter" name="class_text" size="58" value="" disabled onchange="processChange(this)" onBlur="processChange(this)">
-	        </li>
-	    </ul>
-    </td>
+						<td>
+							<label data-disabled="true" for="event_allocation_filter_size_min">Minimum size:</label>
+						</td>		        
+						<td>
+							<input type="number" id="event_allocation_filter_size_min" name="event_allocation_filter_size_min" min="1" max="9999" value="256" disabled onchange="processChange(this)" onBlur="processChange(this)">
+							<select id="event_allocation_filter_units_min" name="event_allocation_filter_units_min" size="1" disabled onchange="processChange(this)">
+								<option value=""> bytes </option>
+								<option value="k" selected> kilobytes</option>
+								<option value="m"> megabytes </option>
+							</select>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<label data-disabled="true" for="event_allocation_filter_size_max">Maximum size:</label>
+						</td>
+						<td>
+							<input type="number" id="event_allocation_filter_size_max" name="event_allocation_filter_size_max" min="1" max="9999" value="512" disabled onchange="processChange(this)" onBlur="processChange(this)">
+							<select id="event_allocation_filter_units_max" name="event_allocation_filter_units_max" size="1" disabled onchange="processChange(this)">
+								<option value=""> bytes </option>
+								<option value="k" selected> kilobytes</option>
+								<option value="m"> megabytes </option>
+							</select>
+						</td>
+					</tr>
+				</table>
+			</li>
+			<hr>
+			<li>
+				<input type="checkbox" id="event_throw"        name="event" value="throw"       onchange="processChange(this)" data-hasfilter="true">
+				<label for="event_throw">Exception thrown by Java code</label>
+				</li>
+			<li>
+				<input type="checkbox" id="event_systhrow"     name="event" value="systhrow"    onchange="processChange(this)" data-hasfilter="true">
+				<label for="event_systhrow">Exception thrown by JVM internals</label>
+			</li>
+			<li>
+				<input type="checkbox" id="event_catch"        name="event" value="catch"       onchange="processChange(this)" data-hasfilter="true">
+				<label for="event_catch">Exception caught</label>
+			</li>
+			<li>
+				<input type="checkbox" id="event_uncaught"     name="event" value="uncaught"    onchange="processChange(this)" data-hasfilter="true">
+				<label for="event_uncaught">Exception uncaught</label>
+				<table>
+					<tr>
+						<td><label data-disabled="true" for="event_throwable_class">Exception class name:</label></td>
+						<td><input style="width: 375px" type="text" id="event_throwable_class" name="throwable_class" size="41" value="" disabled onchange="processChange(this)" onBlur="processChange(this)"></td>
+					</tr>
+					<tr>
+						<td><label data-disabled="true" for="event_throwable_method">Method name / offset:</label></td>
+						<td nowrap>
+							<input style="width: 300px" type="text" id="event_throwable_method" name="throwable_method" size="30" value="" disabled onchange="processChange(this)" onBlur="processChange(this)">
+							<input type="number" id="event_throwable_offset" name="range_first" min="0" max="999" value="0" size="4" disabled onchange="processChange(this)" onBlur="processChange(this)" onBlur="processChange(this)">
+						</td>
+					</tr>
+					<tr>
+						<td><label data-disabled="true" for="event_throwable_msg_filter">Exception message:</label></td>
+						<td><input style="width: 375px" type="text" id="event_throwable_msg_filter" name="throwable_message" size="41" value="" disabled onchange="processChange(this)" onBlur="processChange(this)"></td>
+					</tr>
+				</table>
+			</li>
+			<hr>
+			<li>
+				<input type="checkbox" id="event_load"         name="event" value="load"        onchange="processChange(this)" data-hasfilter="true">
+				<label for="event_load">Class loaded</label>
+			</li>
+			<li>
+				<input type="checkbox" id="event_unload"       name="event" value="unload"      onchange="processChange(this)" data-hasfilter="true">
+				<label for="event_unload">Class unloaded</label><br>
+				<label data-disabled="true" for="event_class_filter">Class name:</label> <input style="width: 450px" type="text" id="event_class_filter" name="class_text" size="58" value="" disabled onchange="processChange(this)" onBlur="processChange(this)">
+			</li>
+		</ul>
+	</td>
 
-    <td>
-        <b style="font-size: 12pt">Dump Agents</b>
-        <ul id="agent_input">
-            <hr>
-            <li>
-    	        <input type="checkbox" id="agent_stack"   name="agent" value="stack"   onchange="processChange(this)">
-		        <label for="agent_stack">Write current Java&trade; thread stack to stderr</label>
-	        </li>
-            <li>
-        	    <input type="checkbox" id="agent_console" name="agent" value="console" onchange="processChange(this)">
-		        <label for="agent_console">Write all Java thread stacks to stderr</label>
-            </li>
-            <li>
-        	    <input type="checkbox" id="agent_system"  name="agent" value="system"  onchange="processChange(this)">
-        		<label for="agent_system">Generate a system dump (core file)</label>
-            </li>
-            <li>
-	            <input type="checkbox" id="agent_java"    name="agent" value="java"    onchange="processChange(this)">
-		        <label for="agent_java">Generate a Java dump (Java core)</label>
-	        </li>
-            <li>
-	            <input type="checkbox" id="agent_heap"    name="agent" value="heap"    onchange="processChange(this)">
-	            <label for="agent_heap">Generate a PHD heap dump (system dump is usually preferred)</label>
-	        </li>
-            <li>
-	            <input type="checkbox" id="agent_snap"    name="agent" value="snap"    onchange="processChange(this)">
-		        <label for="agent_snap">Generate a Snap trace</label>
-	        </li>
-            <li>
-	            <input type="checkbox" id="agent_jit"     name="agent" value="jit"     onchange="processChange(this)">
-		        <label for="agent_jit">Generate a JIT dump</label>
-	        </li>
-	        <li>
-	            <input type="checkbox" id="agent_tool"    name="agent" value="tool"    onchange="processChange(this)">
-		        <label for="agent_tool">Run a shell command:</label><br> 
-		            <input style="width: 540px" type="text" id="exec" name="exec" size="72" value="" disabled onchange="processChange(this)" onBlur="processChange(this)">
-			        <div style="padding: 4px 0px;">
-			            <input type="button" data-target="exec" data-token="%Y"    id="exec_button_year4"  disabled style="font-size: 8pt; height:20px;width:55px" onclick="processChange(this)"
-				            value="Year (4)" title="Year (4 digits) e.g. 2017">
-			            <input type="button" data-target="exec" data-token="%y"    id="exec_button_year2"  disabled style="font-size: 8pt; height:20px;width:55px" onclick="processChange(this)"
-				            value="Year (2)" title="Year (4 digits) e.g. 17">
+	<td>
+		<b style="font-size: 12pt">Dump Agents</b>
+		<ul id="agent_input">
+			<hr>
+			<li>
+				<input type="checkbox" id="agent_stack"   name="agent" value="stack"   onchange="processChange(this)">
+				<label for="agent_stack">Write current Java&trade; thread stack to stderr</label>
+			</li>
+			<li>
+				<input type="checkbox" id="agent_console" name="agent" value="console" onchange="processChange(this)">
+				<label for="agent_console">Write all Java thread stacks to stderr</label>
+			</li>
+			<li>
+				<input type="checkbox" id="agent_system"  name="agent" value="system"  onchange="processChange(this)">
+				<label for="agent_system">Generate a system dump (core file)</label>
+			</li>
+			<li>
+				<input type="checkbox" id="agent_java"    name="agent" value="java"    onchange="processChange(this)">
+				<label for="agent_java">Generate a Java dump (Java core)</label>
+			</li>
+			<li>
+				<input type="checkbox" id="agent_heap"    name="agent" value="heap"    onchange="processChange(this)">
+				<label for="agent_heap">Generate a PHD heap dump (system dump is usually preferred)</label>
+			</li>
+			<li>
+				<input type="checkbox" id="agent_snap"    name="agent" value="snap"    onchange="processChange(this)">
+				<label for="agent_snap">Generate a Snap trace</label>
+			</li>
+			<li>
+				<input type="checkbox" id="agent_jit"     name="agent" value="jit"     onchange="processChange(this)">
+				<label for="agent_jit">Generate a JIT dump</label>
+			</li>
+			<li>
+				<input type="checkbox" id="agent_tool"    name="agent" value="tool"    onchange="processChange(this)">
+				<label for="agent_tool">Run a shell command:</label><br> 
+				<input style="width: 540px" type="text" id="exec" name="exec" size="72" value="" disabled onchange="processChange(this)" onBlur="processChange(this)">
+				<div style="padding: 4px 0px;">
+					<input type="button" data-target="exec" data-token="%Y"    id="exec_button_year4"  disabled style="font-size: 8pt; height:20px;width:55px" onclick="processChange(this)"
+						value="Year (4)" title="Year (4 digits) e.g. 2017">
+					<input type="button" data-target="exec" data-token="%y"    id="exec_button_year2"  disabled style="font-size: 8pt; height:20px;width:55px" onclick="processChange(this)"
+						value="Year (2)" title="Year (4 digits) e.g. 17">
 				        <input type="button" data-target="exec" data-token="%m"    id="exec_button_month"  disabled style="font-size: 8pt; height:20px;width:50px" onclick="processChange(this)"
-				            value="Month" title="Month (2 digits) e.g. 08">
-			            <input type="button" data-target="exec" data-token="%d"    id="exec_button_day"    disabled style="font-size: 8pt; height:20px;width:41px" onclick="processChange(this)"
-				            value="Day" title="Day of month (2 digits) e.g. 26">
-			            <input type="button" data-target="exec" data-token="%H"    id="exec_button_hour"   disabled style="font-size: 8pt; height:20px;width:41px" onclick="processChange(this)"
-				            value="Hour" title="Hour of day (2 digits) e.g. 05">
-			            <input type="button" data-target="exec" data-token="%M"    id="exec_button_minute" disabled style="font-size: 8pt; height:20px;width:41px" onclick="processChange(this)"
-				            value="Min" title="Minute of hour (2 digits) e.g. 47">
-			            <input type="button" data-target="exec" data-token="%S"    id="exec_button_second" disabled style="font-size: 8pt; height:20px;width:41px" onclick="processChange(this)"
-				            value="Sec" title="Second of minute (2 digits) e.g. 35">
-			        </div>
-			        <div>
-			            <input type="button" data-target="exec" data-token="%pid"  id="exec_button_pid"         disabled style="font-size: 8pt; height:20px;width:43px" onclick="processChange(this)"
-				            value="PID" title="JVM Process ID e.g. 27491">
-			            <input type="button" data-target="exec" data-token="%uid"  id="exec_button_uname"       disabled style="font-size: 8pt; height:20px;width:50px" onclick="processChange(this)"
-				            value="Uname" title="User name e.g. jbloggs">
-			            <input type="button" data-target="exec" data-token="%seq"  id="exec_button_dumpcounter" disabled style="font-size: 8pt; height:20px;width:80px" onclick="processChange(this)"
-				            value="Dump Count" title="Dump Counter e.g. 0004">
-			            <input type="button" data-target="exec" data-token="%tick" id="exec_button_mscounter"   disabled style="font-size: 8pt; height:20px;width:80px" onclick="processChange(this)"
-				            value="msec Count" title="Millisecond counter e.g. 638349">
-			            <input type="button" data-target="exec" data-token="%home" id="exec_button_javahome"    disabled style="font-size: 8pt; height:20px;width:80px" onclick="processChange(this)"
-				            value="Java Home" title="Java Home e.g. /home/jbloggs/java">
-			        </div>
-	        </li>
-	        <hr>
-        </ul>
-    </td>
+						value="Month" title="Month (2 digits) e.g. 08">
+					<input type="button" data-target="exec" data-token="%d"    id="exec_button_day"    disabled style="font-size: 8pt; height:20px;width:41px" onclick="processChange(this)"
+						value="Day" title="Day of month (2 digits) e.g. 26">
+					<input type="button" data-target="exec" data-token="%H"    id="exec_button_hour"   disabled style="font-size: 8pt; height:20px;width:41px" onclick="processChange(this)"
+						value="Hour" title="Hour of day (2 digits) e.g. 05">
+					<input type="button" data-target="exec" data-token="%M"    id="exec_button_minute" disabled style="font-size: 8pt; height:20px;width:41px" onclick="processChange(this)"
+						value="Min" title="Minute of hour (2 digits) e.g. 47">
+					<input type="button" data-target="exec" data-token="%S"    id="exec_button_second" disabled style="font-size: 8pt; height:20px;width:41px" onclick="processChange(this)"
+						value="Sec" title="Second of minute (2 digits) e.g. 35">
+						&nbsp;
+						<input type="checkbox" id="tool_async" name="tool_async" value="ASYNC" title="If checked, don't wait for the command to complete before continuing" disabled onchange="processChange(this)">
+						<label for="tool_async" data-disabled="true" title="If checked, don't wait for the command to complete before continuing">Run asynchronously</label>
+				</div>
+				<div>
+					<input type="button" data-target="exec" data-token="%pid"  id="exec_button_pid"         disabled style="font-size: 8pt; height:20px;width:43px" onclick="processChange(this)"
+						value="PID" title="JVM Process ID e.g. 27491">
+					<input type="button" data-target="exec" data-token="%uid"  id="exec_button_uname"       disabled style="font-size: 8pt; height:20px;width:50px" onclick="processChange(this)"
+						value="Uname" title="User name e.g. jbloggs">
+					<input type="button" data-target="exec" data-token="%seq"  id="exec_button_dumpcounter" disabled style="font-size: 8pt; height:20px;width:80px" onclick="processChange(this)"
+						value="Dump Count" title="Dump Counter e.g. 0004">
+					<input type="button" data-target="exec" data-token="%tick" id="exec_button_mscounter"   disabled style="font-size: 8pt; height:20px;width:80px" onclick="processChange(this)"
+						value="msec Count" title="Millisecond counter e.g. 638349">
+					<input type="button" data-target="exec" data-token="%home" id="exec_button_javahome"    disabled style="font-size: 8pt; height:20px;width:80px" onclick="processChange(this)"
+						value="Java Home" title="Java Home e.g. /home/jbloggs/java">
+						&nbsp;&nbsp;
+						<label for="tool_wait" data-disabled="true" title="Time to wait after executing the command, in milliseconds">Wait (ms): </label>
+						<input type="number" id="tool_wait" name="tool_wait" min="0" value="0" disabled title="Time to wait after executing the command, in milliseconds" onchange="processChange(this)">
+				</div>
+			</li>
+			<hr>
+		</ul>
+	</td>
 </tr>
 
 <tr>
-    <td>
-        <b style="font-size: 12pt">Dump Options</b>
-        <ul id="options_input">
-            <hr>
-            <li>
-	            <input type="checkbox" id="range" name="range" value="range" onchange="processChange(this)">
-		        <label for="range">Range of events</label>
-		        <table>
-		            <tr>
-			            <td><label data-disabled="true" for="range_first">First occurrence:</label></td>
-				        <td><input type="number" id="range_first" name="range_first" min="1" max="9999" value="1" size="4" disabled onchange="processChange(this)" onBlur="processChange(this)"></td>
-			        </tr>
-			        <tr>
-			            <td><label data-disabled="true" for="range_last">Last occurrence:</label></td>
-				        <td>
-				            <input type="number" id="range_last" name="range_last" min="0" max="9999" value="0" size="4" disabled onchange="processChange(this)" onBlur="processChange(this)">
-					        <label data-disabled="true" for="range_last">(0 = no limit)</label>
-				        </td>
-			        </tr>
-		        </table>
-	        </li>
+	<td>
+		<b style="font-size: 12pt">Dump Options</b>
+		<ul id="options_input">
+			<hr>
+			<li id="range_li">
+				<table>
+					<tr>
+						<td><label for="range_first">First event:</label></td>
+						<td><input type="number" id="range_first" name="range_first" min="1" max="9999" value="1" size="4" onchange="processChange(this)" onBlur="processChange(this)"></td>
+					</tr>
+					<tr>
+						<td><label for="range_last">Last event:</label></td>
+						<td>
+							<input type="number" id="range_last" name="range_last" min="0" max="9999" value="0" size="4" onchange="processChange(this)" onBlur="processChange(this)">
+							<label for="range_last">(0 = no limit)</label>
+						</td>
+					</tr>
+				</table>
+			</li>
 			<hr>
 			<li>
-			    <input type="checkbox" id="priority" name="priority" value="priority" onchange="processChange(this)">
+				<input type="checkbox" id="priority" name="priority" value="priority" onchange="processChange(this)">
 				<label for="priority">Dump priority:</label>
 				<input type="number" id="priority_value" name="priority_value" min="0" max="999" size="4" disabled onchange="processChange(this)" onBlur="processChange(this)">
 				<label data-disabled="true" for="priority_value">(0 [lowest] - 999 [highest])</label>
 			</li>
 			<hr>
-	        <div id="request_input">
-	            <li>
-		            <input type="checkbox" id="request_exclusive" name="request" value="exclusive" onchange="processChange(this)">
-			        <label for="request_exclusive">Obtain exclusive JVM access before dumping</label>
-		        </li>
-		        <li>
-		            <input type="checkbox" id="request_compact"   name="request" value="compact"   onchange="processChange(this)">
-			        <label for="request_compact">Run global GC before dumping (i.e. remove garbage objects)</label>
-		        </li>
-		        <li>
-		            <input type="checkbox" id="request_prepwalk"  name="request" value="prepwalk"  onchange="processChange(this)">
-			        <label for="request_prepwalk">Ensure heap is walkable before dumping</label>
-		        </li>
-		        <li>
-		            <input type="checkbox" id="request_serial"    name="request" value="serial"    onchange="processChange(this)">
-			        <label for="request_serial">Suspend other dumps while dumping</label>
-		        </li>
-		        <li>
-		            <input type="checkbox" id="request_preempt"   name="request" value="preempt"   onchange="processChange(this)">
-			        <label for="request_preempt">Enable native thread stacks in javacore</label>
-		        </li>
-	        </div>
-	    	<hr>
-	        <li>
-	            <input type="checkbox" id="file"    name="file" value="file"  disabled  onchange="processChange(this)">
-		        <label for="file" data-disabled="true">Custom dump file name (applies to all enabled dump types):</label> 
-		            <input style="width: 540px" type="text" id="file_text" name="file_text" size="71" value="" disabled onchange="processChange(this)" onBlur="processChange(this)">
-			        <div style="padding: 4px 0px;">
-			            <input type="button" data-target="file_text" data-token="%Y"    id="file_button_year4"  disabled style="font-size: 8pt; height:20px;width:55px" onclick="processChange(this)"
-				            value="Year (4)" title="Year (4 digits) e.g. 2017">
-			            <input type="button" data-target="file_text" data-token="%y"    id="file_button_year2"  disabled style="font-size: 8pt; height:20px;width:55px" onclick="processChange(this)"
-				            value="Year (2)" title="Year (4 digits) e.g. 17">
-				        <input type="button" data-target="file_text" data-token="%m"    id="file_button_month"  disabled style="font-size: 8pt; height:20px;width:50px" onclick="processChange(this)"
-				            value="Month" title="Month (2 digits) e.g. 08">
-			            <input type="button" data-target="file_text" data-token="%d"    id="file_button_day"    disabled style="font-size: 8pt; height:20px;width:41px" onclick="processChange(this)"
-				            value="Day" title="Day of month (2 digits) e.g. 26">
-			            <input type="button" data-target="file_text" data-token="%H"    id="file_button_hour"   disabled style="font-size: 8pt; height:20px;width:41px" onclick="processChange(this)"
-				            value="Hour" title="Hour of day (2 digits) e.g. 05">
-			            <input type="button" data-target="file_text" data-token="%M"    id="file_button_minute" disabled style="font-size: 8pt; height:20px;width:41px" onclick="processChange(this)"
-				            value="Min" title="Minute of hour (2 digits) e.g. 47">
-			            <input type="button" data-target="file_text" data-token="%S"    id="file_button_second" disabled style="font-size: 8pt; height:20px;width:41px" onclick="processChange(this)"
-				            value="Sec" title="Second of minute (2 digits) e.g. 35">
-			        </div>
-			        <div>
-			            <input type="button" data-target="file_text" data-token="%pid"  id="file_button_pid"         disabled style="font-size: 8pt; height:20px;width:43px" onclick="processChange(this)"
-				            value="PID" title="JVM Process ID e.g. 27491">
-			            <input type="button" data-target="file_text" data-token="%uid"  id="file_button_uname"       disabled style="font-size: 8pt; height:20px;width:50px" onclick="processChange(this)"
-				            value="Uname" title="User name e.g. jbloggs">
-			            <input type="button" data-target="file_text" data-token="%seq"  id="file_button_dumpcounter" disabled style="font-size: 8pt; height:20px;width:80px" onclick="processChange(this)"
-				            value="Dump Count" title="Dump Counter e.g. 0004">
-			            <input type="button" data-target="file_text" data-token="%tick" id="file_button_mscounter"   disabled style="font-size: 8pt; height:20px;width:80px" onclick="processChange(this)"
-				            value="msec Count" title="Millisecond counter e.g. 638349">
-			            <input type="button" data-target="file_text" data-token="%home" id="file_button_javahome"    disabled style="font-size: 8pt; height:20px;width:80px" onclick="processChange(this)"
-				            value="Java Home" title="Java Home e.g. /home/jbloggs/java">
-			        </div>
-	        </li>
-	    </ul>
-    </td>
+			<div id="request_input">
+				<li>
+					<input type="checkbox" id="request_exclusive" name="request" value="exclusive" onchange="processChange(this)">
+					<label for="request_exclusive">Obtain exclusive JVM access before dumping</label>
+				</li>
+				<li>
+					<input type="checkbox" id="request_compact"   name="request" value="compact"   onchange="processChange(this)">
+					<label for="request_compact">Run global GC before dumping (i.e. remove garbage objects)</label>
+				</li>
+				<li>
+					<input type="checkbox" id="request_prepwalk"  name="request" value="prepwalk"  onchange="processChange(this)">
+					<label for="request_prepwalk">Ensure heap is walkable before dumping</label>
+				</li>
+				<li>
+					<input type="checkbox" id="request_serial"    name="request" value="serial"    onchange="processChange(this)">
+					<label for="request_serial">Suspend other dumps while dumping</label>
+				</li>
+				<li>
+					<input type="checkbox" id="request_preempt"   name="request" value="preempt"   onchange="processChange(this)">
+					<label for="request_preempt">Enable native thread stacks in javacore</label>
+				</li>
+		        </div>
+			<hr>
+			<li>
+				<input type="checkbox" id="file"    name="file" value="file"  disabled  onchange="processChange(this)">
+				<label for="file" data-disabled="true">Custom dump file name (applies to all enabled dump types):</label> 
+				<input style="width: 540px" type="text" id="file_text" name="file_text" size="71" value="" disabled onchange="processChange(this)" onBlur="processChange(this)">
+				<div style="padding: 4px 0px;">
+					<input type="button" data-target="file_text" data-token="%Y"    id="file_button_year4"  disabled style="font-size: 8pt; height:20px;width:55px" onclick="processChange(this)"
+						value="Year (4)" title="Year (4 digits) e.g. 2017">
+					<input type="button" data-target="file_text" data-token="%y"    id="file_button_year2"  disabled style="font-size: 8pt; height:20px;width:55px" onclick="processChange(this)"
+						value="Year (2)" title="Year (4 digits) e.g. 17">
+					<input type="button" data-target="file_text" data-token="%m"    id="file_button_month"  disabled style="font-size: 8pt; height:20px;width:50px" onclick="processChange(this)"
+						value="Month" title="Month (2 digits) e.g. 08">
+					<input type="button" data-target="file_text" data-token="%d"    id="file_button_day"    disabled style="font-size: 8pt; height:20px;width:41px" onclick="processChange(this)"
+						value="Day" title="Day of month (2 digits) e.g. 26">
+					<input type="button" data-target="file_text" data-token="%H"    id="file_button_hour"   disabled style="font-size: 8pt; height:20px;width:41px" onclick="processChange(this)"
+						value="Hour" title="Hour of day (2 digits) e.g. 05">
+					<input type="button" data-target="file_text" data-token="%M"    id="file_button_minute" disabled style="font-size: 8pt; height:20px;width:41px" onclick="processChange(this)"
+						value="Min" title="Minute of hour (2 digits) e.g. 47">
+					<input type="button" data-target="file_text" data-token="%S"    id="file_button_second" disabled style="font-size: 8pt; height:20px;width:41px" onclick="processChange(this)"
+						value="Sec" title="Second of minute (2 digits) e.g. 35">
+				</div>
+				<div>
+					<input type="button" data-target="file_text" data-token="%pid"  id="file_button_pid"         disabled style="font-size: 8pt; height:20px;width:43px" onclick="processChange(this)"
+						value="PID" title="JVM Process ID e.g. 27491">
+					<input type="button" data-target="file_text" data-token="%uid"  id="file_button_uname"       disabled style="font-size: 8pt; height:20px;width:50px" onclick="processChange(this)"
+						value="Uname" title="User name e.g. jbloggs">
+					<input type="button" data-target="file_text" data-token="%seq"  id="file_button_dumpcounter" disabled style="font-size: 8pt; height:20px;width:80px" onclick="processChange(this)"
+						value="Dump Count" title="Dump Counter e.g. 0004">
+					<input type="button" data-target="file_text" data-token="%tick" id="file_button_mscounter"   disabled style="font-size: 8pt; height:20px;width:80px" onclick="processChange(this)"
+						value="msec Count" title="Millisecond counter e.g. 638349">
+					<input type="button" data-target="file_text" data-token="%home" id="file_button_javahome"    disabled style="font-size: 8pt; height:20px;width:80px" onclick="processChange(this)"
+						value="Java Home" title="Java Home e.g. /home/jbloggs/java">
+				</div>
+			</li>
+		</ul>
+	</td>
 </tr>
 
 <tr>
-    <td colspan="2">
-        <hr>
-        <b><p id="result" style="font-size: 14pt; font-family:courier;">&nbsp;</p></b>
-        <hr>
-        <p>
+	<td colspan="2">
+		<hr>
+		<b><p id="result" style="font-size: 14pt; font-family:courier;">&nbsp;</p></b>
+		<hr>
+		<p>
 			<input type="checkbox" id="wrap_in_quotes" name="wrap_in_quotes" value="wrap_in_quotes" onchange="processChange(this)">
-        	<label for="wrap_in_quotes">Wrap in quotes (for use in a shell)</label>
+			<label for="wrap_in_quotes">Wrap in quotes (for use in a shell)</label>
 		</p>
 		<p>
-            <button type="button" id="button_copy_to_clipboard" style="font-size: 12pt; height:30px;width:200px" onclick="copyTextToClipboard(document.getElementById('result'))" title="Copy this -Xdump option to the clipboard">Copy option</button>
-    	    <button type="button" id="button_copy_link_to_clipboard" style="font-size: 12pt; height:30px;width:200px" onclick="copyLinkToClipboard()" title="Copy a link to this -Xdump option to the clipboard">Copy link</button>
-    		<button type="button" id="button_reset" style="font-size: 12pt; height:30px;width:200px" onclick="location.reload()"title="Reset all options to the values that were set when this page was originally loaded">Reset</button>
+			<button type="button" id="button_copy_to_clipboard" style="font-size: 12pt; height:30px;width:200px" onclick="copyTextToClipboard(document.getElementById('result'))" title="Copy this -Xdump option to the clipboard">Copy option</button>
+			<button type="button" id="button_copy_link_to_clipboard" style="font-size: 12pt; height:30px;width:200px" onclick="copyLinkToClipboard()" title="Copy a link to this -Xdump option to the clipboard">Copy link</button>
+			<button type="button" id="button_reset" style="font-size: 12pt; height:30px;width:200px" onclick="location.reload()"title="Reset all options to the values that were set when this page was originally loaded">Reset</button>
 			<button type="button" id="button_clear" style="font-size: 12pt; height:30px;width:200px" onclick="clearAndReload()" title="Clear all options and set default values">Clear</button>
-			&nbsp;
 		</p>
-	<p id="errors" style="font-size: 12pt; font-family:courier; color:red;">&nbsp;</p></b>
-    </td>
+		<p id="errors" style="font-size: 12pt; font-family:courier; color:red;">&nbsp;</p></b>
+	</td>
 </tr>
 
 </table>

--- a/tools/xtrace_option_builder.html
+++ b/tools/xtrace_option_builder.html
@@ -1,4 +1,3 @@
-﻿
 <!--
 TODO:
 - what is the difference between j9util and j9vmutil?
@@ -28,94 +27,94 @@ var methodCounter = 0;
 var triggerCounter = 0;
 
 function initialSetup() {
-    parseParams();
+	parseParams();
 }
 
 function parseParams() {
 	if (location.search != "") {
-        // Get the query part of the URL, remove the leading '?', and split on '&'
-        var params = location.search.substring(1).split("&"); // this includes the '?' so need to substring it
+		// Get the query part of the URL, remove the leading '?', and split on '&'
+		var params = location.search.substring(1).split("&"); // this includes the '?' so need to substring it
 
 		for (var i = 0; i < params.length; i++) {
-	        var param = params[i].split("=");
+			var param = params[i].split("=");
 			var key = param[0];
 			var value = param[1];
-    		
+
 			// Tracepoints
 			if (key.substring(0,11) == "tracepoint_") {
-			    parseTracepointParam(key, value);
+				parseTracepointParam(key, value);
 				continue; // Go to the next parameter
 			}
-			
+
 			// Methods
 			if (key.substring(0,7) == "method_") {
-			    parseMethodParam(key, value);
+				parseMethodParam(key, value);
 				continue; // Go to the next parameter
-		    }
-			
+			}
+
 			// Triggers
 			if (key.substring(0,8) == "trigger_") {
-			    parseTriggerParam(key, value);
+				parseTriggerParam(key, value);
 				continue; // Go to the next parameter
 			}
-			
+
 			// If we reach here this is a select/input outside of a tracepoint/method/trigger
 			var element = document.getElementById(key);
-			
+
 			// Check whether the ID was valid
 			if (element == null) {
-			    console.log("ERROR: Key does not map to element: " + key);
+				console.log("ERROR: Key does not map to element: " + key);
 				continue; // Go to the next parameter
 			}
-			
+
 			// Select
 			if (element.tagName == "SELECT") {
-			    if (!selectOptionByValue(element, value)) {
-				    console.log("ERROR: Invalid value for select element \"" + element.id + "\": " + value);
+				if (!selectOptionByValue(element, value)) {
+					console.log("ERROR: Invalid value for select element \"" + element.id + "\": " + value);
 				}
 				processChange(element);
 				element.blur();
 				continue; // Go to the next parameter
 			}
-			
+
 			// Input
 			if (element.tagName == "INPUT") {
-			    switch (element.type) {
-				    case "text":
-					    // id = URI encoded value
+				switch (element.type) {
+					case "text":
+						// id = URI encoded value
 						element.value = decodeURIComponent(value);
 						break;
-					
+
 					case "number":
-					    // id = value
+						// id = value
 						element.value = value;
-				        break;
-					
+				        	break;
+
 					case "checkbox":
 						// id = 0|1 (unchecked|checked)
-    		            switch (value) {
-			                case "0":
-				                element.checked = false;
-					            break;
-			    
-				            case "1":
-				                element.checked = true;
-					            break;
-					
-				            default:
-				                console.log("ERROR: Invalid value for checkbox element \"" + element.id + "\": " + value);
-			                    continue; // Go to the next parameter
-			            }						
-                        break;				
+						switch (value) {
+							case "0":
+								element.checked = false;
+								break;
+
+							case "1":
+						                element.checked = true;
+								break;
+
+							default:
+								console.log("ERROR: Invalid value for checkbox element \"" + element.id + "\": " + value);
+								continue; // Go to the next parameter
+						}						
+						break;				
 				}
-				
+
 				processChange(element);
 				element.blur();
 				continue; // Go to the next parameter
 			}		
 		}
 	} else {
-	    // If no parameters were provided, just build the result with the defaults
+		// If no parameters were provided, just build the result with the defaults
 		buildAndUpdateResult();
 	}
 }
@@ -123,60 +122,60 @@ function parseParams() {
 // Parse a tracepoint key/value parameter pair
 function parseTracepointParam(key, value) {
 	var regexArray = key.match(/tracepoint_(.+)_(\d+)/)
-    
+
 	if (regexArray == null) {
-	    console.log("ERROR: Invalid tracepoint key: " + key);
-	    return;		
+		console.log("ERROR: Invalid tracepoint key: " + key);
+		return;		
 	}
-	
+
 	var type = regexArray[1];
 	var tracepointIndex = regexArray[2];
-	
+
 	if (type != "id" && type != "component") {
 		console.log("ERROR: Invalid tracepoint type in key \"" + key + "\": "  + type);
-	    return;		
+		return;		
 	}
-	
+
 	// Add the tracepoint
 	addTracepoint(type, null);
-				
+
 	// Update the form elements
 	// Decode the "value" and split it into an array of parameters
 	var tracepointParams = decodeURIComponent(value).split("&");
 	for (var j = 0; j < tracepointParams.length; j++) {
-	    var tracepointParam = tracepointParams[j].split("=");
+		var tracepointParam = tracepointParams[j].split("=");
 		var tracepointKey = tracepointParam[0];
-        var tracepointValue = tracepointParam[1];
-		
+		var tracepointValue = tracepointParam[1];
+
 		var element = document.getElementById(tracepointKey);
-		
+
 		// Check whether the ID was valid
 		if (element == null) {
-		    console.log("ERROR: Key does not map to element: " + tracepointKey);
+			console.log("ERROR: Key does not map to element: " + tracepointKey);
 			continue; // Go to the next parameter
 		}
-		
+
 		switch (element.tagName) {
-		    case "SELECT":
-			    // id = selected value
+			case "SELECT":
+				// id = selected value
 				if (!selectOptionByValue(element, tracepointValue)) {
-				    console.log("ERROR: Invalid value for select element \"" + element.id + "\": " + tracepointValue);
+					console.log("ERROR: Invalid value for select element \"" + element.id + "\": " + tracepointValue);
 					continue; // Go to the next parameter
 				}				
 				break;
-			
+
 			case "INPUT":
-			    if (element.type == "text") {
-				    // id = URI encoded value
+				if (element.type == "text") {
+					// id = URI encoded value
 					element.value = decodeURIComponent(tracepointValue);
 				}
 				if (element.type == "radio") {
-				    if (tracepointValue == 1) {
-				        // id = 1 (checked) (unchecked radio options are not included) 
-					    element.checked = true;
-				    } else {
-					    console.log("ERROR: Invalid value for radio input\"" + element.id + "\": " + tracepointValue);
-					    continue; // Go to the next parameter
+					if (tracepointValue == 1) {
+						// id = 1 (checked) (unchecked radio options are not included) 
+						element.checked = true;
+					} else {
+						console.log("ERROR: Invalid value for radio input\"" + element.id + "\": " + tracepointValue);
+						continue; // Go to the next parameter
 					}
 				}
 				break;
@@ -189,57 +188,57 @@ function parseTracepointParam(key, value) {
 // Parse a method key/value parameter pair
 function parseMethodParam(key, value) {
 	var regexArray = key.match(/method_(\d+)/)
-    
+
 	if (regexArray == null) {
-	    console.log("ERROR: Invalid method key: " + key);
-	    return;		
+		console.log("ERROR: Invalid method key: " + key);
+		return;		
 	}
-	
+
 	var methodIndex = regexArray[1];
-			    
+
 	// Add the method
 	addMethod();
-				
+
 	// Update the form elements
 	// Decode the "value" and split it into an array of parameters
 	var methodParams = decodeURIComponent(value).split("&");
 	for (var j = 0; j < methodParams.length; j++) {
-	    var methodParam = methodParams[j].split("=");
+		var methodParam = methodParams[j].split("=");
 		var methodKey = methodParam[0];
-        var methodValue = methodParam[1];
-					
+		var methodValue = methodParam[1];
+
 		var element = document.getElementById(methodKey);
-		
+
 		// Check whether the ID was valid
 		if (element == null) {
-		    console.log("ERROR: Key does not map to element: " + methodKey);
+			console.log("ERROR: Key does not map to element: " + methodKey);
 			continue; // Go to the next parameter
 		}
-		
+
 		// meth_text
 		if (element.type == "text") {
-		    // id = URI encoded value
+			// id = URI encoded value
 			element.value = decodeURIComponent(methodValue);
 		}
-					
+
 		// meth_args
 		if (element.type == "checkbox") {
-		    // id = 0|1 (unchecked|checked)
-    		switch (methodValue) {
-			    case "0":
-				    element.checked = false;
+			// id = 0|1 (unchecked|checked)
+			switch (methodValue) {
+				case "0":
+					element.checked = false;
 					break;
-			    
+
 				case "1":
-				    element.checked = true;
+					element.checked = true;
 					break;
-					
+
 				default:
-				    console.log("ERROR: Invalid value for checkbox element \"" + element.id + "\": " + methodValue);
-			        continue; // Go to the next parameter
+					console.log("ERROR: Invalid value for checkbox element \"" + element.id + "\": " + methodValue);
+					continue; // Go to the next parameter
 			}
 		}
-					
+
 		processChange(element);
 		element.blur();
 	}
@@ -248,55 +247,55 @@ function parseMethodParam(key, value) {
 // Parse a trigger key/value parameter pair
 function parseTriggerParam(key, value) {
 	var regexArray = key.match(/trigger_(.+)_(\d+)/)
-    
+
 	if (regexArray == null) {
-	    console.log("ERROR: Invalid trigger key: " + key);
-	    return;		
+		console.log("ERROR: Invalid trigger key: " + key);
+		return;		
 	}
-	
+
 	var type = regexArray[1];
 	var triggerIndex = regexArray[2];
-	
+
 	if (type != "method" && type != "tracepoint" && type != "group") {
-	    console.log("ERROR: Invalid trigger type in key \"" + key + "\": " + type);
-	    return;		
+		console.log("ERROR: Invalid trigger type in key \"" + key + "\": " + type);
+		return;		
 	}
-	
+
 	// Add the trigger
 	addTrigger(type);
-	
+
 	// Update the form elements
 	// Decode the "value" and split it into an array of parameters
 	var triggerParams = decodeURIComponent(value).split("&");
 	for (var j = 0; j < triggerParams.length; j++) {
-	    var triggerParam = triggerParams[j].split("=");
+		var triggerParam = triggerParams[j].split("=");
 		var triggerKey = triggerParam[0];
-        var triggerValue = triggerParam[1];
-					
+		var triggerValue = triggerParam[1];
+
 		var element = document.getElementById(triggerKey);
-		
+
 		// Check whether the ID was valid
 		if (element == null) {
-		    console.log("ERROR: Key does not map to element: " + triggerKey);
+			console.log("ERROR: Key does not map to element: " + triggerKey);
 			continue; // Go to the next parameter
 		}
-		
+
 		switch (element.tagName) {
-		    case "SELECT":
-			    // id = selected value
+			case "SELECT":
+				// id = selected value
 				if (!selectOptionByValue(element, triggerValue)) {
-				    console.log("ERROR: Invalid value for select element \"" + element.id + "\": " + triggerValue);
+					console.log("ERROR: Invalid value for select element \"" + element.id + "\": " + triggerValue);
 					continue; // Go to the next parameter
 				}
 				break;
-						
+
 			case "INPUT":
-			    if (element.type == "text") {
-				    // id = URI encoded value
+				if (element.type == "text") {
+					// id = URI encoded value
 					element.value = decodeURIComponent(triggerValue);
 				}
 				if (element.type == "radio") {
-				    // id = value
+					// id = value
 					element.value = triggerValue;
 				}
 				break;
@@ -309,347 +308,346 @@ function parseTriggerParam(key, value) {
 function processChange(option) {
 	// Ensure that only compatible tracepoint groups are enabled for the current component
 	if (option.id != null && option.id.indexOf("tp_comp_select_") != -1) {
-	    var regexArray = option.id.match(/tp_comp_select_(\d+)/)
+		var regexArray = option.id.match(/tp_comp_select_(\d+)/)
 		var tracepointIndex = regexArray[1];
 		var selectElement = document.getElementById("tp_group_select_" + tracepointIndex);
-		
+
 		switch(option.value) {
-		    case "all":
-			    enableAllOptions(selectElement);
+			case "all":
+				enableAllOptions(selectElement);
 				break;
-				
-		    case "mt":
-			    disableAllOptions(selectElement);
+
+			case "mt":
+				disableAllOptions(selectElement);
 				enableOption(selectElement, "all");
-                enableOption(selectElement, "compiledmethods");
+				enableOption(selectElement, "compiledmethods");
 				enableOption(selectElement, "nativemethods");
 				enableOption(selectElement, "staticmethods");
 				break;
-				
-		    case "j9jcl":
-			    disableAllOptions(selectElement);
+
+			case "j9jcl":
+				disableAllOptions(selectElement);
 				enableOption(selectElement, "all");
 				enableOption(selectElement, "verboseclass");
 				break;
-				
-		    case "j9jit":
-			    disableAllOptions(selectElement);
+
+			case "j9jit":
+				disableAllOptions(selectElement);
 				enableOption(selectElement, "all");
 				enableOption(selectElement, "verbose");
 				break;
-				
-		    case "j9jni":
-			    disableAllOptions(selectElement);
+
+			case "j9jni":
+				disableAllOptions(selectElement);
 				enableOption(selectElement, "all");
 				enableOption(selectElement, "checkjni");
 				break;
-				
-		    case "j9mm":
-			    disableAllOptions(selectElement);
+
+			case "j9mm":
+				disableAllOptions(selectElement);
 				enableOption(selectElement, "all");
 				enableOption(selectElement, "gclogger");
 				break;
-				
-		    case "j9prt":
-			    disableAllOptions(selectElement);
+
+			case "j9prt":
+				disableAllOptions(selectElement);
 				enableOption(selectElement, "all");
 				enableOption(selectElement, "nlsmessage");
 				break;
-				
-		    case "j9vm":
-			    disableAllOptions(selectElement);
+
+			case "j9vm":
+				disableAllOptions(selectElement);
 				enableOption(selectElement, "all");
 				enableOption(selectElement, "verboseclass");
 				enableOption(selectElement, "checkjni");
 				enableOption(selectElement, "checkmemory");
 				enableOption(selectElement, "checkvm");
 				break;
-		    
+
 			default:
-			    disableAllOptions(selectElement);
+				disableAllOptions(selectElement);
 				break;
 		}
-		
+
 		// If the currently selected option is now disabled, reset selection to "all"
 		var selectedOptionElement = getSelectedElement(selectElement);
 		if (selectedOptionElement.disabled) {
-		    selectedOptionElement.selected = false;
+			selectedOptionElement.selected = false;
 			document.getElementById("tp_group_option_all_" + tracepointIndex).selected = true;
 		}
-		
+
 		// If all the group options are disabled, switch to "type" and disable the group option completely
 		if (areAllOptionsDisabled(selectElement)) {
-		    // Switch to the type option and enable it, just in case it was disabled
+			// Switch to the type option and enable it, just in case it was disabled
 			document.getElementById("tp_type_" + tracepointIndex).checked = true;
 			enableInput(document.getElementById("tp_type_" + tracepointIndex));
 			enableInput(document.getElementById("tp_type_select_" + tracepointIndex));
-			
+
 			// Disable the group option
 			disableInput(document.getElementById("tp_group_" + tracepointIndex));
 			disableInput(document.getElementById("tp_group_select_" + tracepointIndex));
 		} else {
-		    // At least one option is enabled so enable "group", just in case it was disabled
+			// At least one option is enabled so enable "group", just in case it was disabled
 			enableInput(document.getElementById("tp_group_" + tracepointIndex));
 		}
 	}
-	
+
 	// Enable/disable the type/group fields in a tracepoint form
 	if (option.id != null && option.name.indexOf("tp_type_or_group_") != -1) {
-	    var regexArray = option.name.match(/tp_type_or_group_(\d+)/)
+		var regexArray = option.name.match(/tp_type_or_group_(\d+)/)
 		var tracepointIndex = regexArray[1];
 		if (option.value == "type") {
-		    if (option.checked) {
-			    enableInput(document.getElementById("tp_type_select_" + tracepointIndex));
+			if (option.checked) {
+				enableInput(document.getElementById("tp_type_select_" + tracepointIndex));
 				disableInput(document.getElementById("tp_group_select_" + tracepointIndex));
 			}		
 		}
-		
+
 		if (option.value == "group") {
-		    if (option.checked) {
-			    enableInput(document.getElementById("tp_group_select_" + tracepointIndex));
+			if (option.checked) {
+				enableInput(document.getElementById("tp_group_select_" + tracepointIndex));
 				disableInput(document.getElementById("tp_type_select_" + tracepointIndex));
 			}		
 		}
 	}
-	
+
 	// If no tracepoint qualifier parameters are entered, all tracepoints are enabled,
-    // except for exception.output trace, where the default is all {exception}.
+	// except for exception.output trace, where the default is all {exception}.
 	if (option.id != null && option.id.indexOf("tp_dest_select_") != -1) {
-	    var regexArray = option.id.match(/tp_dest_select_(\d+)/)
+		var regexArray = option.id.match(/tp_dest_select_(\d+)/)
 		var tracepointIndex = regexArray[1];
 		if (option.parentNode.getAttribute("data-type") == "component") {
-		    if (document.getElementById("tp_dest_exception_" + tracepointIndex).selected) {
-    		    if (document.getElementById("tp_comp_all_" + tracepointIndex).selected) {
-			        document.getElementById("tp_type_exception_" + tracepointIndex).selected = true;
-			    }
+			if (document.getElementById("tp_dest_exception_" + tracepointIndex).selected) {
+				if (document.getElementById("tp_comp_all_" + tracepointIndex).selected) {
+					document.getElementById("tp_type_exception_" + tracepointIndex).selected = true;
+				}
 			}
 		}
 	}	
-	
+
 	// Attempt to correct formatting mistakes in method text fields
 	if (option.type == "text"
-	    && (   option.id.indexOf("meth_text_") != -1
+		&& (   option.id.indexOf("meth_text_") != -1
 		    || option.id.indexOf("trig_meth_spec_") != -1) )
 	{
-	    // Check for more than one dot in the string
-		if (   option.value.indexOf(".") != -1
-		    && (option.value.indexOf(".") != option.value.lastIndexOf(".")) )
+		// Check for more than one dot in the string
+		if (option.value.indexOf(".") != -1
+			&& (option.value.indexOf(".") != option.value.lastIndexOf(".")) )
 		{
-		    // Replace dots with slashes until there is only one dot left
+			// Replace dots with slashes until there is only one dot left
 			// This is a best effort, and isn't always going to work
 			while (option.value.indexOf(".") != option.value.lastIndexOf(".")) {
-			    option.value = option.value.replace(".", "/");
+				option.value = option.value.replace(".", "/");
 			}
-	    }
-		
+		}
+
 		// Remove brackets if present
 		option.value = option.value.replace(/\(|\)/g, '');
 	}
-	
+
 	// Fix obvious mistakes in tracepoint ID fields
 	if (   option.id != null
-	    && (option.id.indexOf("trig_tp_tpnid_") != -1
+		&& (   option.id.indexOf("trig_tp_tpnid_") != -1
 		    || option.id.indexOf("tp_id_") != -1) )
-    {
-	    var result = "";
+	{
+		var result = "";
 		var specs = option.value.split(",");
 		for (var i = 0; i < specs.length; i++) {
-	        // Remove any whitespace
+			// Remove any whitespace
 			var fixedSpec = specs[i].replace(/\s/g,'');
-			
+
 			// Fix case if necessary (see https://github.com/eclipse/openj9/issues/1254)
 			fixedSpec = fixTracepointIdCase(fixedSpec);
-			
+
 			result += fixedSpec + ",";
-	    }
-		
-		// Remove any trailing commas
-	    while (result.length > 0 && result.lastIndexOf(",") == result.length - 1) {
-		    result = removeFinalCommaIfPresent(result);
 		}
-		
+
+		// Remove any trailing commas
+		while (result.length > 0 && result.lastIndexOf(",") == result.length - 1) {
+			result = removeFinalCommaIfPresent(result);
+		}
+
 		option.value = result;
 	}
-	
+
 	// Enable the disable_predefined checkbox if we are tracing to maximal buffers,
 	// and disabled otherwise. This is because the tracepoints that are enabled by
 	// default are traced to maximal buffers. We only care about them if we're
 	// tracing to the dame destination.
 	if (isMaximalTracepointDestinationEnabled()) {
-	    enableInput(document.getElementById("disable_predefined"));
+		enableInput(document.getElementById("disable_predefined"));
 	} else {
-	    disableInput(document.getElementById("disable_predefined"));
+		disableInput(document.getElementById("disable_predefined"));
 	}
-	
+
 	// Enable the sleeptime field if a thread sleep action is selected
 	if (isThreadSleepActionSelected()) {
-	    enableInput(document.getElementById("sleep_time"));
+		enableInput(document.getElementById("sleep_time"));
 	} else {
-	    disableInput(document.getElementById("sleep_time"));
+		disableInput(document.getElementById("sleep_time"));
 	}
-	
+
 	// Enable the stack depth field if a jstacktrace trigger action is selected
-	if (isTracepointJStackTraceActionSelected() || isMethodJStackTraceActionSelected) {
-	    enableInput(document.getElementById("stack_depth"));
+	if (isTracepointJStackTraceActionSelected() || isMethodJStackTraceActionSelected()) {
+		enableInput(document.getElementById("stack_depth"));
 	} else {
-	    disableInput(document.getElementById("stack_depth"));
+		disableInput(document.getElementById("stack_depth"));
 	}
-	
+
 	// If this change was to select a jstacktrace trigger action, make sure
 	// a suitable trace tracepoint is enabled to control the destination
-	if (   option.id != null
-	    && (   option.id.indexOf("trig_meth_ent_") != -1
+	if (option.id != null
+		&& (   option.id.indexOf("trig_meth_ent_") != -1
 		    || option.id.indexOf("trig_meth_ex_") != -1
-			|| option.id.indexOf("trig_tp_act_") != -1
-			|| option.id.indexOf("trig_grp_act_") != -1) )
+		    || option.id.indexOf("trig_tp_act_") != -1
+		    || option.id.indexOf("trig_grp_act_") != -1) )
 	{
-	    var regexArray = option.id.match(/_(\d+)/)
+		var regexArray = option.id.match(/_(\d+)/)
 		var triggerIndex = regexArray[1];
 		var selectedElement = getSelectedElement(document.getElementById(option.id));
 		if (selectedElement.id.indexOf("jstacktrace") != -1) {
-    		if (option.id.indexOf("trig_tp_act_") != -1) {
-			    // This is a tracepoint ID trigger
+    			if (option.id.indexOf("trig_tp_act_") != -1) {
+				// This is a tracepoint ID trigger
 				var triggerTracepointId = document.getElementById("trig_tp_tpnid_" + triggerIndex).value;
-		        if (!isIdTracepointEnabled(triggerTracepointId) && !isAllTracepointEnabled()) {
-				    addTracepoint("id", "null");
+				if (!isIdTracepointEnabled(triggerTracepointId) && !isAllTracepointEnabled()) {
+					addTracepoint("id", "null");
 					var newTracepointElement = document.getElementById("tp_id_" + (tracepointCounter - 1));
-		            newTracepointElement.value = triggerTracepointId;
+					newTracepointElement.value = triggerTracepointId;
 				}
 			} else {
-			    // This is a method trigger
+				// This is a method trigger
 				if (!isMethodTracepointEnabled() && !isAllTracepointEnabled()) {
-		            addTracepoint("component", "mt");			
-		        }
+					addTracepoint("component", "mt");			
+				}
 			}
 		}
-    }
-	
-	// If a tracepoint action or method trigger entry action is set to start tracing, automatically disable tracing at startup
-	if (   option.id != null
-	    && (   option.id.indexOf("trig_meth_ent_") != -1
-		    || option.id.indexOf("trig_tp_act_") != -1
-			|| option.id.indexOf("trig_grp_act_") != -1) )
-	{
-	    var selectedElement = getSelectedElement(document.getElementById(option.id));
-		if (selectedElement.id.indexOf("resume") != -1) {
-	        document.getElementById("trace_initially_disabled").checked = true;
-	    }
 	}
-	
+
+	// If a tracepoint action or method trigger entry action is set to start tracing, automatically disable tracing at startup
+	if (option.id != null
+		&& (   option.id.indexOf("trig_meth_ent_") != -1
+		    || option.id.indexOf("trig_tp_act_") != -1
+		    || option.id.indexOf("trig_grp_act_") != -1) )
+	{
+		var selectedElement = getSelectedElement(document.getElementById(option.id));
+		if (selectedElement.id.indexOf("resume") != -1) {
+			document.getElementById("trace_initially_disabled").checked = true;
+		}
+	}
+
 	// If one of the token buttons is pressed, add the token to the text input
 	if (option.type == "button" && option.getAttribute("data-target") != null) {
-	    insertText(document.getElementById(option.getAttribute("data-target")), option.getAttribute("data-token"));
+		insertText(document.getElementById(option.getAttribute("data-target")), option.getAttribute("data-token"));
 	}
-	
+
 	// Remove focus from input element (ensures error styling works correctly)
 	if (option.id != null) {
 		option.blur();
 	}
-	
+
 	// Check which destinations are selected and enable/disable output forms accordingly
 	checkOutputForms();
-		
-    // Build the result string and display it
+
+	// Build the result string and display it
 	buildAndUpdateResult();
 }
 
 // Checks which destinations are enabled, and enables/disables output forms accordingly
 function checkOutputForms() {
-    var needOutputForm = false;
+	var needOutputForm = false;
 	var needExceptionOutputForm = false;
-	
+
 	for (var i = 0; i < tracepointCounter; i++) {
-        var destinationSelectElement = document.getElementById("tp_dest_select_" + i)
-	    if (destinationSelectElement != null) {
-		    var destination = getSelectedElement(destinationSelectElement).value;
+		var destinationSelectElement = document.getElementById("tp_dest_select_" + i)
+		if (destinationSelectElement != null) {
+			var destination = getSelectedElement(destinationSelectElement).value;
 			switch (getSelectedElement(destinationSelectElement).value) {
-			    case "minimal":
-	            case "maximal":
-                    needOutputForm = true;
+				case "minimal":
+				case "maximal":
+					needOutputForm = true;
 					break;
-                    
+
 				case "exception":
-                    needExceptionOutputForm = true;
-	    			break;
-                    
-                default:
-                    break;					
+					needExceptionOutputForm = true;
+					break;
+
+				default:
+					break;					
 			}
 		}
-    }
+	}
 
 	// Need to disable buffer size/units and dynamic buffers as well
 	// Don't enable dynamic buffers though if need output form - that's handled elsewhere
 	// Or should we move that to this function?
-	
+
 	if (needOutputForm) {
-	    enableInput(document.getElementById("file_text"));
+		enableInput(document.getElementById("file_text"));
 		enableInput(document.getElementById("output_size"));
 		enableInput(document.getElementById("output_generations"));
 	} else {
-	    disableInput(document.getElementById("file_text"));
+		disableInput(document.getElementById("file_text"));
 		disableInput(document.getElementById("output_size"));
 		disableInput(document.getElementById("output_generations"));
 	}
 
-    if (needExceptionOutputForm) {
-	    enableInput(document.getElementById("file_text_exception"));
+	if (needExceptionOutputForm) {
+		enableInput(document.getElementById("file_text_exception"));
 		enableInput(document.getElementById("output_size_exception"));
 	} else {
-	    disableInput(document.getElementById("file_text_exception"));
+		disableInput(document.getElementById("file_text_exception"));
 		disableInput(document.getElementById("output_size_exception"));
 	}
 	
 	if (needOutputForm || needExceptionOutputForm) {
-	    enableInput(document.getElementById("buffer_size"));
+		enableInput(document.getElementById("buffer_size"));
 		enableInput(document.getElementById("buffer_size_units"));
 	} else {
-	    disableInput(document.getElementById("buffer_size"));
+		disableInput(document.getElementById("buffer_size"));
 		disableInput(document.getElementById("buffer_size_units"));
 	}
-	
+
 	// The dynamic buffers option only applies when tracing to a file
 	// TODO: Doc is not 100% clear - does this definitely apply for output AND exception.output?
 	if ((needOutputForm && isOutputFileSpecified())
-	    || (needExceptionOutputForm	&& isExceptionOutputFileSpecified) )
+		|| (needExceptionOutputForm && isExceptionOutputFileSpecified) )
 	{
 		enableInput(document.getElementById("dynamic_buffers"));
 	} else {
-	    disableInput(document.getElementById("dynamic_buffers"));
+		disableInput(document.getElementById("dynamic_buffers"));
 	}
 }
 
-
 function addTracepoint(type, defaultComponent) {
-    var tracepointList = document.getElementById("tracepoint_input");
+	var tracepointList = document.getElementById("tracepoint_input");
 	var newTracepoint = document.createElement("li");
 	newTracepoint.setAttribute("id", "tracepoint_" + tracepointCounter);
 	newTracepoint.setAttribute("data-type", type);
-	
+
 	newTracepoint.innerHTML =
-	    '<a href="javascript:void(0)" title="Remove tracepoint" class="remove" id="remove_tracepoint_' + tracepointCounter + '" onclick="removeTracepoint(' + tracepointCounter + ')">&#x274C</a>' +
+		'<a href="javascript:void(0)" title="Remove tracepoint" class="remove" id="remove_tracepoint_' + tracepointCounter + '" onclick="removeTracepoint(' + tracepointCounter + ')">&#x274C</a>' +
 		'&nbsp;&nbsp;' +
-	    '<select id="tp_dest_select_' + tracepointCounter + '" onchange="processChange(this)">' +
-        '    <option id="tp_dest_maximal_'   + tracepointCounter + '"  value="maximal"  selected >Trace to buffers (maximal)</option>' +
-        '    <option id="tp_dest_minimal_'   + tracepointCounter + '"  value="minimal"           >Trace to buffers (minimal)</option>' +
-        '    <option id="tp_dest_count_'     + tracepointCounter + '"  value="count"             >Trace to buffers (count only)</option>' +
-        '    <option id="tp_dest_exception_' + tracepointCounter + '"  value="exception"         >Trace to Exception buffers</option>' +
-        '    <option id="tp_dest_print_'     + tracepointCounter + '"  value="print"             >Trace to STDERR (standard)</option>' +
-        '    <option id="tp_dest_iprint_'    + tracepointCounter + '"  value="iprint"            >Trace to STDERR (indented)</option>' +
-        '    <option id="tp_dest_external_'  + tracepointCounter + '"  value="external"          >Trace to external receiver</option>' +
-        '    <option id="tp_dest_none_'      + tracepointCounter + '"  value="none"              >None (disable tracepoint)</option>' +
+		'<select id="tp_dest_select_' + tracepointCounter + '" onchange="processChange(this)">' +
+		'    <option id="tp_dest_maximal_'   + tracepointCounter + '"  value="maximal"  selected >Trace to buffers (maximal)</option>' +
+		'    <option id="tp_dest_minimal_'   + tracepointCounter + '"  value="minimal"           >Trace to buffers (minimal)</option>' +
+		'    <option id="tp_dest_count_'     + tracepointCounter + '"  value="count"             >Trace to buffers (count only)</option>' +
+		'    <option id="tp_dest_exception_' + tracepointCounter + '"  value="exception"         >Trace to Exception buffers</option>' +
+		'    <option id="tp_dest_print_'     + tracepointCounter + '"  value="print"             >Trace to STDERR (standard)</option>' +
+		'    <option id="tp_dest_iprint_'    + tracepointCounter + '"  value="iprint"            >Trace to STDERR (indented)</option>' +
+		'    <option id="tp_dest_external_'  + tracepointCounter + '"  value="external"          >Trace to external receiver</option>' +
+		'    <option id="tp_dest_none_'      + tracepointCounter + '"  value="none"              >None (disable tracepoint)</option>' +
 		'</select>' +
 		'&nbsp;&nbsp;';
-		
+
 	if (type == "id") {
-	    newTracepoint.innerHTML += 
-		    '<label for="tp_id_' + tracepointCounter + '">Tracepoint <a href="https://www.ibm.com/support/knowledgecenter/en/SSYKE2_8.0.0/com.ibm.java.lnx.80.doc/diag/tools/trace_tracepoint.html#trace_tracepoint">ID</a>: </label>' +
+		newTracepoint.innerHTML += 
+			'<label for="tp_id_' + tracepointCounter + '">Tracepoint <a href="https://www.ibm.com/support/knowledgecenter/en/SSYKE2_8.0.0/com.ibm.java.lnx.80.doc/diag/tools/trace_tracepoint.html#trace_tracepoint">ID</a>: </label>' +
 			'<input type="text" id="tp_id_' + tracepointCounter + '" name="tp_id_' + tracepointCounter + '" size="10" value="" onchange="processChange(this)" onblur="processChange(this)">';
 	}
-	
+
 	if (type == "component") {
-	    newTracepoint.innerHTML +=
-		    '<select id="tp_comp_select_'         + tracepointCounter + '" onchange="processChange(this)">' +
+		newTracepoint.innerHTML +=
+			'<select id="tp_comp_select_'         + tracepointCounter + '" onchange="processChange(this)">' +
 			'    <option id="tp_comp_all_'        + tracepointCounter + '" value="all" selected >All components</option>' +
 			'    <option id="tp_comp_mt_'         + tracepointCounter + '" value="mt"           >Methods / Stacks (see below)</option>' +
 			' 	 <option id="tp_comp_ibm_gpu_'    + tracepointCounter + '" value="ibm_gpu"      >JCL - GPU</option>' +
@@ -723,136 +721,135 @@ function addTracepoint(type, defaultComponent) {
 			'    </select>' +
 			'</input>';
 	}
-	
+
 	tracepointList.appendChild(newTracepoint);
-	
+
 	// Tooltip: Trace Destination field
 	var tooltipText = "Trace Destination\n" +
-	                  "\n" +
-	                  "Trace buffers:\n" +
-	                  "    - can be continually written to one or more files (see \"Regular output file\" field)\n" +
-	                  "    - can be \"snapped\" to a file (known as a \"snap trace\" or \"snap dump\")\n" +
-					  "\n" +
-	                  "Exception buffers:\n" +
-	                  "    - *must* be continually written to a file (see \"Exception output file\" field)";
+		"\n" +
+		"Trace buffers:\n" +
+		"    - can be continually written to one or more files (see \"Regular output file\" field)\n" +
+		"    - can be \"snapped\" to a file (known as a \"snap trace\" or \"snap dump\")\n" +
+		"\n" +
+		"Exception buffers:\n" +
+		"    - *must* be continually written to a file (see \"Exception output file\" field)";
 	document.getElementById("tp_dest_select_" + tracepointCounter).title = tooltipText;
-	
+
 	if (type == "id") {
-	    idInputElement = document.getElementById("tp_id_" + tracepointCounter);
-		
+		idInputElement = document.getElementById("tp_id_" + tracepointCounter);
+
 		// Tooltip: ID field
-        tooltipText = "Examples:\n" + 
-		              "    - j9prt.5\n" +
-		              "    - j9prt.5-15\n" +
-					  "    - j9prt.5-15,j9vm.12\n";
+		tooltipText = "Examples:\n" + 
+			"    - j9prt.5\n" +
+			"    - j9prt.5-15\n" +
+			"    - j9prt.5-15,j9vm.12\n";
 		idInputElement.title = tooltipText;
-		
+
 		// Give focus to the id field
 		idInputElement.focus();
 	}
-	
+
 	if (type == "component") {
-	    // Tooltip: Component field
-	    tooltipText = "Component to trace";
+		// Tooltip: Component field
+		tooltipText = "Component to trace";
 		document.getElementById("tp_comp_select_" + tracepointCounter).title = tooltipText;
-    
-	    // Tooltip: Level field
+
+		// Tooltip: Level field
 		tooltipText = "A Level 0 tracepoint is the most important. It is reserved for extraordinary\n" +
-		              "events and errors. A Level 9 tracepoint is in-depth component detail.\n" +
-					  "\n" +
-					  "Example: if Level 5 is selected, tracepoints with Levels from 0 to 5 are included.";
+			"events and errors. A Level 9 tracepoint is in-depth component detail.\n" +
+			"\n" +
+			"Example: if Level 5 is selected, tracepoints with Levels from 0 to 5 are included.";
 		document.getElementById("tp_level_select_" + tracepointCounter).title = tooltipText;
-	
-	    // Tooltip: Type field
+
+		// Tooltip: Type field
 		tooltipText = "Tracepoint type";
 		document.getElementById("tp_type_select_" + tracepointCounter).title = tooltipText;
-		
+
 		// Tooltip: Group field
-	    tooltipText = "Tracepoint group";
+		tooltipText = "Tracepoint group";
 		document.getElementById("tp_group_select_" + tracepointCounter).title = tooltipText;
-		
 	}
-	
+
 	if (type == "component" && defaultComponent != null) {
-	    // Select the specified component
-	    document.getElementById("tp_comp_" + defaultComponent + "_" + tracepointCounter).selected = true;
+		// Select the specified component
+		document.getElementById("tp_comp_" + defaultComponent + "_" + tracepointCounter).selected = true;
 		// Call processChange against the component select element to ensure that the
 		// correct options are shown in the group select field
 		processChange(document.getElementById("tp_comp_select_" + tracepointCounter));
 	}
-	
+
 	tracepointCounter++;
 	processChange("none");
 }
 
 function removeTracepoint(tracepointIndex) {
-    var tracepoint = document.getElementById("tracepoint_" + tracepointIndex);
-    tracepoint.parentNode.removeChild(tracepoint);
+	var tracepoint = document.getElementById("tracepoint_" + tracepointIndex);
+	tracepoint.parentNode.removeChild(tracepoint);
 	processChange("none");
 }
  
 function addMethod() {
-    // If no method trace tracepoint is enabled, add one
+	// If no method trace tracepoint is enabled, add one
 	if (!isMethodTracepointEnabled() && !isAllTracepointEnabled()) {
-	    addTracepoint("component", "mt");
+		addTracepoint("component", "mt");
 	}
-	
-    // Add a method form	
+
+	// Add a method form	
 	var newMethod = document.createElement("li");
 	newMethod.setAttribute("id", "method_" + methodCounter);
 	newMethod.innerHTML =
 		'<a href="javascript:void(0)" title="Remove method" class="remove" id="remove_method_' + methodCounter + '" onclick="removeMethod(' + methodCounter + ')">&#x274C</a>' +
 		'&nbsp;&nbsp;' +
 		'<label for="meth_text_' + methodCounter + '">Method: </label>' +
-        '<input type="text" id="meth_text_' + methodCounter + '" name="meth_text_' + methodCounter + '" size="25" value="" onchange="processChange(this)" onblur="processChange(this)">' +
+		'<input type="text" id="meth_text_' + methodCounter + '" name="meth_text_' + methodCounter + '" size="25" value="" onchange="processChange(this)" onblur="processChange(this)">' +
 		'&nbsp;&nbsp;' +
 		'<input type="checkbox" id="meth_args_' + methodCounter + '" name="meth_args_' + methodCounter + '" value="meth_args_' + methodCounter + '" checked onchange="processChange(this)">' +
 		'<label for="meth_args_' + methodCounter + '">Trace arguments and return values</label>';
-	
+
 	var methodList = document.getElementById("method_input");
-    methodList.appendChild(newMethod);
+	methodList.appendChild(newMethod);
 
 	var methodTextElement = document.getElementById("meth_text_" + methodCounter);
-	
+
 	// Tooltip: Method text field
-    var tooltipText = "Examples:\n" + 
-	                  "    - java/lang/String.indexOf\n" +
-                      "    - java/nio/ByteBuffer.*\n" +
-                      "    - java/util/*.*\n" +
-                      "    - *.readObject\n" +
-                      "    - *.*\n" +
-                      "\n" +
-                      "Note that methods parameters cannot be specified.\n" +
-	                  "All methods matching the specified name will be traced.";
+	var tooltipText = "Examples:\n" + 
+		"    - java/lang/String.indexOf\n" +
+		"    - java/nio/ByteBuffer.*\n" +
+		"    - java/util/*.*\n" +
+		"    - *.readObject\n" +
+		"    - *.*\n" +
+		"\n" +
+		"Note that methods parameters cannot be specified.\n" +
+		"All methods matching the specified name will be traced.";
 	methodTextElement.title = tooltipText;
-	
+
 	// Give focus to text field
 	methodTextElement.focus();
-	
-    methodCounter++;
+
+	methodCounter++;
 	processChange("none");
 }
 
 function removeMethod(methodIndex) {
-    var method = document.getElementById("method_" + methodIndex);
+	var method = document.getElementById("method_" + methodIndex);
 	method.parentNode.removeChild(method);
 	processChange("none");
 }
 
 function addTrigger(type) {
-    var triggerList = document.getElementById("trigger_input");
+	var triggerList = document.getElementById("trigger_input");
 	var newTrigger = document.createElement("li");
 	newTrigger.setAttribute("id", "trigger_" + triggerCounter);
 	newTrigger.setAttribute("data-type", type);
-	
+
 	newTrigger.innerHTML =
-	    '<a href="javascript:void(0)" title="Remove trigger" class="remove" id="remove_trigger_' + triggerCounter + '" onclick="removeTrigger(' + triggerCounter + ')">&#x274C</a>' +
+		'<a href="javascript:void(0)" title="Remove trigger" class="remove" id="remove_trigger_' + triggerCounter + '" onclick="removeTrigger(' + triggerCounter + ')">&#x274C</a>' +
 		'&nbsp;&nbsp;';	
-	
+
 	if (type == "method") {
-	    // method{<methodspec>[,<entryAction>[,<exitAction>[,<delayCount>[,<matchcount>]]]]}
+		// method{<methodspec>[,<entryAction>[,<exitAction>[,<delayCount>[,<matchcount>]]]]}
 		newTrigger.innerHTML +=
-		    '<label for="trig_meth_spec_' + triggerCounter + '">Method: </label>' +
+			'<label for="trig_meth_spec_' + triggerCounter + '">Method: </label>' +
 			'<input type="text" id="trig_meth_spec_' + triggerCounter +'" name="trig_meth_spec_1" size="25" value="" onchange="processChange(this)" onblur="processChange(this)">' +
 			'&nbsp;&nbsp;' +
 			'<label for="trig_meth_ent_' + triggerCounter + '">Entry: </label>' +
@@ -890,11 +887,11 @@ function addTrigger(type) {
 			'</select>' +
 			'&nbsp;&nbsp;';
 	}
-	
+
 	if (type == "tracepoint") {
-	    // tpnid{<tpnid>|<tpnidRange>,<action>[,<delayCount>[,<matchcount>]]}
+		// tpnid{<tpnid>|<tpnidRange>,<action>[,<delayCount>[,<matchcount>]]}
 		newTrigger.innerHTML +=
-	        '<label for "trig_tp_tpnid_' + tracepointCounter + '">Tracepoint <a href="https://www.ibm.com/support/knowledgecenter/en/SSYKE2_8.0.0/com.ibm.java.lnx.80.doc/diag/tools/trace_tracepoint.html#trace_tracepoint">ID</a>: </label>' +
+			'<label for "trig_tp_tpnid_' + tracepointCounter + '">Tracepoint <a href="https://www.ibm.com/support/knowledgecenter/en/SSYKE2_8.0.0/com.ibm.java.lnx.80.doc/diag/tools/trace_tracepoint.html#trace_tracepoint">ID</a>: </label>' +
 			'<input type="text" id="trig_tp_tpnid_'        + triggerCounter +'" name="trig_tp_tpnid_1" size="10" value="" onchange="processChange(this)" onblur="processChange(this)">' +
 			'&nbsp;&nbsp;' +
 			'<select id="trig_tp_act_' + triggerCounter + '" onchange="processChange(this)">' +
@@ -914,126 +911,126 @@ function addTrigger(type) {
 			'</select>' +
 			'&nbsp;&nbsp;';
 	}
-	
+
 	if (type == "group") {
-	    // group{<groupname>,<action>[,<delayCount>[,<matchcount>]]}
+		// group{<groupname>,<action>[,<delayCount>[,<matchcount>]]}
 		newTrigger.innerHTML +=
-		    '<label for "trig_grp_name_' + tracepointCounter + '">Tracepoint group: </label>' +
-		    '<select id="trig_grp_name_' + triggerCounter + '" onchange="processChange(this)">' +
-		    '    <option id="trig_grp_name_gclogger_'        + triggerCounter + '" value="gclogger"        >GC Logger</option>' +
-    		'    <option id="trig_grp_name_nlsmessage_'      + triggerCounter + '" value="nlsmessage"      >NLS Messages</option>' +
-    		'    <option id="trig_grp_name_verboseclass_'    + triggerCounter + '" value="verboseclass"    >Verbose:class</option>' +
-		    '    <option id="trig_grp_name_checkjni_'        + triggerCounter + '" value="checkjni"        >Check:JNI</option>' +
-		    '    <option id="trig_grp_name_checkmemory_'     + triggerCounter + '" value="checkmemory"     >Check:memory</option>' +' +' +
-		    '    <option id="trig_grp_name_checkvm_'         + triggerCounter + '" value="checkvm"         >Check:VM</option>' +
-		    '    <option id="trig_grp_name_verbose_'         + triggerCounter + '" value="verbose"         >Verbose</option>' +
-		    '    <option id="trig_grp_name_compiledmethods_' + triggerCounter + '" value="compiledmethods" >Compiled methods</option>' +
-		    '    <option id="trig_grp_name_nativemethods_'   + triggerCounter + '" value="nativemethods"   >Native methods</option>' +
-		    '    <option id="trig_grp_name_staticmethods_'   + triggerCounter + '" value="staticmethods"   >Static methods</option>' +
-		    '</select>' +
-		    '&nbsp;&nbsp;' +
-		    '<select id="trig_grp_act_' + triggerCounter + '" onchange="processChange(this)">' +
-		    '    <option id="trig_grp_act_none_'        + triggerCounter + '" value="none"        >No action</option>' +
-		    '    <option id="trig_grp_act_javadump_'    + triggerCounter + '" value="javadump"    >Javacore</option>' +
-		    '    <option id="trig_grp_act_sysdump_'     + triggerCounter + '" value="sysdump"     >System dump (core file)</option>' +
-		    '    <option id="trig_grp_act_heapdump_'    + triggerCounter + '" value="heapdump"    >Heap dump</option>' +
-		    '    <option id="trig_grp_act_snap_'        + triggerCounter + '" value="snap"        >Snap trace</option>' +
-		    '    <option id="trig_grp_act_jstacktrace_' + triggerCounter + '" value="jstacktrace" >Java stacktrace</option>' +
-		    '    <option id="trig_grp_act_resumethis_'  + triggerCounter + '" value="resumethis"  >Start trace (current thread)</option>' +
-		    '    <option id="trig_grp_act_suspendthis_' + triggerCounter + '" value="suspendthis" >Stop trace (current thread)</option>' +
-		    '    <option id="trig_grp_act_resume_'      + triggerCounter + '" value="resume"      >Start trace (all threads)</option>' +
-		    '    <option id="trig_grp_act_suspend_'     + triggerCounter + '" value="suspend"     >Stop trace (all threads)</option>' +
-		    '    <option id="trig_grp_act_sleep_'       + triggerCounter + '" value="sleep"       >Thread sleep</option>' + <!-- TODO: sleeptime -->
-		    '    <option id="trig_grp_act_segv_'        + triggerCounter + '" value="segv"        >SIGSEGV/GPF</option>' +
-		    '    <option id="trig_grp_act_abort_'       + triggerCounter + '" value="abort"       >Abort</option>' +
-		    '</select>' +
-		    '&nbsp;&nbsp;';
+			'<label for "trig_grp_name_' + tracepointCounter + '">Tracepoint group: </label>' +
+			'<select id="trig_grp_name_' + triggerCounter + '" onchange="processChange(this)">' +
+			'    <option id="trig_grp_name_gclogger_'        + triggerCounter + '" value="gclogger"        >GC Logger</option>' +
+			'    <option id="trig_grp_name_nlsmessage_'      + triggerCounter + '" value="nlsmessage"      >NLS Messages</option>' +
+			'    <option id="trig_grp_name_verboseclass_'    + triggerCounter + '" value="verboseclass"    >Verbose:class</option>' +
+			'    <option id="trig_grp_name_checkjni_'        + triggerCounter + '" value="checkjni"        >Check:JNI</option>' +
+			'    <option id="trig_grp_name_checkmemory_'     + triggerCounter + '" value="checkmemory"     >Check:memory</option>' +' +' +
+			'    <option id="trig_grp_name_checkvm_'         + triggerCounter + '" value="checkvm"         >Check:VM</option>' +
+			'    <option id="trig_grp_name_verbose_'         + triggerCounter + '" value="verbose"         >Verbose</option>' +
+			'    <option id="trig_grp_name_compiledmethods_' + triggerCounter + '" value="compiledmethods" >Compiled methods</option>' +
+			'    <option id="trig_grp_name_nativemethods_'   + triggerCounter + '" value="nativemethods"   >Native methods</option>' +
+			'    <option id="trig_grp_name_staticmethods_'   + triggerCounter + '" value="staticmethods"   >Static methods</option>' +
+			'</select>' +
+			'&nbsp;&nbsp;' +
+			'<select id="trig_grp_act_' + triggerCounter + '" onchange="processChange(this)">' +
+			'    <option id="trig_grp_act_none_'        + triggerCounter + '" value="none"        >No action</option>' +
+			'    <option id="trig_grp_act_javadump_'    + triggerCounter + '" value="javadump"    >Javacore</option>' +
+			'    <option id="trig_grp_act_sysdump_'     + triggerCounter + '" value="sysdump"     >System dump (core file)</option>' +
+			'    <option id="trig_grp_act_heapdump_'    + triggerCounter + '" value="heapdump"    >Heap dump</option>' +
+			'    <option id="trig_grp_act_snap_'        + triggerCounter + '" value="snap"        >Snap trace</option>' +
+			'    <option id="trig_grp_act_jstacktrace_' + triggerCounter + '" value="jstacktrace" >Java stacktrace</option>' +
+			'    <option id="trig_grp_act_resumethis_'  + triggerCounter + '" value="resumethis"  >Start trace (current thread)</option>' +
+			'    <option id="trig_grp_act_suspendthis_' + triggerCounter + '" value="suspendthis" >Stop trace (current thread)</option>' +
+			'    <option id="trig_grp_act_resume_'      + triggerCounter + '" value="resume"      >Start trace (all threads)</option>' +
+			'    <option id="trig_grp_act_suspend_'     + triggerCounter + '" value="suspend"     >Stop trace (all threads)</option>' +
+			'    <option id="trig_grp_act_sleep_'       + triggerCounter + '" value="sleep"       >Thread sleep</option>' + <!-- TODO: sleeptime -->
+			'    <option id="trig_grp_act_segv_'        + triggerCounter + '" value="segv"        >SIGSEGV/GPF</option>' +
+			'    <option id="trig_grp_act_abort_'       + triggerCounter + '" value="abort"       >Abort</option>' +
+			'</select>' +
+			'&nbsp;&nbsp;';
 	}
-	
+
 	// Add delay and match/limit fields
 	newTrigger.innerHTML +=
-	    '<label for "trig_delay_' + triggerCounter + '">Delay: </label>' +
-	    '<input type="number" id="trig_delay_' + triggerCounter + '" min="0" max="9999" value="0" size="4" onchange="processChange(this)" onblur="processChange(this)">' +
-	    '&nbsp;&nbsp;' +
-	    '<label for "trig_match_' + triggerCounter + '">Limit: </label>' +
-	    '<input type="number" id="trig_match_' + triggerCounter + '" min="0" max="9999" value="0" size="4" onchange="processChange(this)" onblur="processChange(this)">';
+		'<label for "trig_delay_' + triggerCounter + '">Delay: </label>' +
+		'<input type="number" id="trig_delay_' + triggerCounter + '" min="0" max="9999" value="0" size="4" onchange="processChange(this)" onblur="processChange(this)">' +
+		'&nbsp;&nbsp;' +
+		'<label for "trig_match_' + triggerCounter + '">Limit: </label>' +
+		'<input type="number" id="trig_match_' + triggerCounter + '" min="0" max="9999" value="0" size="4" onchange="processChange(this)" onblur="processChange(this)">';
 	
 	triggerList.appendChild(newTrigger);
 
 	if (type == "tracepoint") {
-	    tpnidElement = document.getElementById("trig_tp_tpnid_" + triggerCounter);
-		
+		tpnidElement = document.getElementById("trig_tp_tpnid_" + triggerCounter);
+
 		// Tooltip: Tracepoint ID
 		var tooltipText = "Examples:\n" + 
-		                  "    - j9prt.5\n" +
-		                  "    - j9prt.5-15\n";
+			"    - j9prt.5\n" +
+			"    - j9prt.5-15\n";
 		tpnidElement.title = tooltipText;
-	
-	    // Tooltip: Action
+
+		// Tooltip: Action
 		document.getElementById("trig_tp_act_" + triggerCounter).title = "Action to perform when a matching tracepoint is encountered";
-	
-	    // Give focus to tpnid field
+
+		// Give focus to tpnid field
 		tpnidElement.focus();
 	}
-	
+
 	if (type == "method") { 
-	    methodSpecElement = document.getElementById("trig_meth_spec_" + triggerCounter);
-		
+		methodSpecElement = document.getElementById("trig_meth_spec_" + triggerCounter);
+
 		// Tooltip: Tracepoint ID
 		var tooltipText = "Examples:\n" + 
-		                  "    - java/lang/String.indexOf\n" +
-                          "    - java/nio/ByteBuffer.*\n" +
-                          "    - java/util/*.*\n" +
-                          "    - MyClass.*\n" +
-                          "    - *.*\n" +
-                          "\n" +
-                          "Note that methods parameters cannot be specified.\n" +
-					      "All methods matching the specified name will fire the trigger.";
+			"    - java/lang/String.indexOf\n" +
+			"    - java/nio/ByteBuffer.*\n" +
+			"    - java/util/*.*\n" +
+			"    - MyClass.*\n" +
+			"    - *.*\n" +
+			"\n" +
+			"Note that methods parameters cannot be specified.\n" +
+			"All methods matching the specified name will fire the trigger.";
 		document.getElementById("trig_meth_spec_" + triggerCounter).title = tooltipText;
-	
-	    // Tooltip: Entry/Exit actions
+
+		// Tooltip: Entry/Exit actions
 		document.getElementById("trig_meth_ent_" + triggerCounter).title = "Action to perform when entering a matching method";
 		document.getElementById("trig_meth_ex_" + triggerCounter).title = "Action to perform when exiting a matching method";
-	
-	    // Give focus to method spec field
+
+		// Give focus to method spec field
 		methodSpecElement.focus();
 	}
-	
+
 	if (type == "group") { 
-	    // Tooltip: Group Name
+		// Tooltip: Group Name
 		document.getElementById("trig_grp_name_" + triggerCounter).title = "Tracepoint group";
-	
-	    // Tooltip: Action
+
+		// Tooltip: Action
 		document.getElementById("trig_grp_act_" + triggerCounter).title = "Action to perform when a tracepoint from the specified group is encountered";
 	}
-	
+
 	// Tooltip: Delay
 	document.getElementById("trig_delay_" + triggerCounter).title = "The action(s) are only run after the trigger has been satisfied this many times\n";
-	
+
 	// Tooltip: Limit/Match
 	document.getElementById("trig_match_" + triggerCounter).title = "The action(s) are only run until the trigger has been satisfied this many times\n";
-	
-    triggerCounter++;
+
+	triggerCounter++;
 	processChange("none");
 }
 
 function removeTrigger(triggerIndex) {
-    var trigger = document.getElementById("trigger_" + triggerIndex);
-    trigger.parentNode.removeChild(trigger);
+	var trigger = document.getElementById("trigger_" + triggerIndex);
+	trigger.parentNode.removeChild(trigger);
 	processChange("none");
 }
 
 // Return the currently selected element within a given "select" element
 function getSelectedElement(selectElement) {
-    return selectElement.options[selectElement.selectedIndex];
+	return selectElement.options[selectElement.selectedIndex];
 }
 
 // Select an option in a <select> element by its value
 function selectOptionByValue(selectElement, valueToSelect) {
-    var optionElements = selectElement.getElementsByTagName("option");
+	var optionElements = selectElement.getElementsByTagName("option");
 	for (var i = 0; i < optionElements.length; i++) {
-	    if (optionElements[i].value == valueToSelect) {
-		    optionElements[i].selected = true;
+		if (optionElements[i].value == valueToSelect) {
+			optionElements[i].selected = true;
 			return true;
 		}
 	}
@@ -1043,128 +1040,128 @@ function selectOptionByValue(selectElement, valueToSelect) {
 
 // Enable's a specific element's HTML label
 function enableLabel(elementId) {
-    var labels = document.getElementsByTagName("label");
-    for (var i = 0; i < labels.length; i++) {
-        if (labels[i].htmlFor == elementId) {
-             labels[i].setAttribute("data-disabled", "false");
-        }
-    }
+	var labels = document.getElementsByTagName("label");
+	for (var i = 0; i < labels.length; i++) {
+		if (labels[i].htmlFor == elementId) {
+			labels[i].setAttribute("data-disabled", "false");
+		}
+	}
 }
 
 // Disables a specific element's HTML label
 function disableLabel(elementId) {
-    var labels = document.getElementsByTagName("label");
-    for (var i = 0; i < labels.length; i++) {
-        if (labels[i].htmlFor == elementId) {
-             labels[i].setAttribute("data-disabled", "true");
-        }
-    }
+	var labels = document.getElementsByTagName("label");
+	for (var i = 0; i < labels.length; i++) {
+		if (labels[i].htmlFor == elementId) {
+			labels[i].setAttribute("data-disabled", "true");
+		}
+	}
 }
 
 // Enables a specific option in a <select> element
 function enableOption(selectElement, optionToEnable) {
 	var optionElements = selectElement.getElementsByTagName("option");
 	for (var i = 0; i < optionElements.length; i++) {
-        if (optionElements[i].value == optionToEnable) {						
+		if (optionElements[i].value == optionToEnable) {						
 			optionElements[i].disabled = false;
 			optionElements[i].style.display = null; // i.e. default
-	    }
-    }
+		}
+	}
 }
 
 // Enables all options in a <select> element
 function enableAllOptions(selectElement) {
 	var optionElements = selectElement.getElementsByTagName("option");
 	for (var i = 0; i < optionElements.length; i++) {
-        optionElements[i].disabled = false;
+		optionElements[i].disabled = false;
 		optionElements[i].style.display = null; // i.e. default
-    }
+	}
 }
 
 // Disables all options in a <select> element
 function disableAllOptions(selectElement) {
 	var optionElements = selectElement.getElementsByTagName("option");
 	for (var i = 0; i < optionElements.length; i++) {
-        optionElements[i].disabled = true;
+		optionElements[i].disabled = true;
 		optionElements[i].style.display = "none";
-    }
+	}
 }
 
 // Returns true if all options in a <select> element are disabled, false otherwise
 function areAllOptionsDisabled(selectElement) {
 	var optionElements = selectElement.getElementsByTagName("option");
 	for (var i = 0; i < optionElements.length; i++) {
-        if (!optionElements[i].disabled) {
-		    return false;
+		if (!optionElements[i].disabled) {
+			return false;
 		}
-    }
+	}
 	return true;
 }
 
 // Returns true if any triggers are using the "sleep" action
 function isThreadSleepActionSelected() {
-    var selectElements = document.getElementsByTagName("select");
-    for (var i = 0; i < selectElements.length; i++) {
-        if (getSelectedElement(selectElements[i]).value == "sleep") {
-             return true;
-        }
-    }
+	var selectElements = document.getElementsByTagName("select");
+	for (var i = 0; i < selectElements.length; i++) {
+		if (getSelectedElement(selectElements[i]).value == "sleep") {
+			return true;
+		}
+	}
 	return false;
 }
 
 // Returns true if any triggers are using the "jstacktrace" action
 function isMethodJStackTraceActionSelected() {
-    var selectElements = document.getElementsByTagName("select");
-    for (var i = 0; i < selectElements.length; i++) {
-        if (   selectElements[i].id.indexOf("trig_meth_ent_") != -1
-		    || selectElements[i].id.indexOf("trig_meth_ex_") != -1)
+	var selectElements = document.getElementsByTagName("select");
+	for (var i = 0; i < selectElements.length; i++) {
+		if (selectElements[i].id.indexOf("trig_meth_ent_") != -1
+			|| selectElements[i].id.indexOf("trig_meth_ex_") != -1)
 		{
-		   if (getSelectedElement(selectElements[i]).value == "jstacktrace") {
-                return true;
-           }
+			if (getSelectedElement(selectElements[i]).value == "jstacktrace") {
+				return true;
+			}
 		}
-    }
+	}
 	return false;
 }
 
 // Returns true if any triggers are using the "jstacktrace" action
 function isTracepointJStackTraceActionSelected() {
-    var selectElements = document.getElementsByTagName("select");
-    for (var i = 0; i < selectElements.length; i++) {
-        if (selectElements[i].id.indexOf("trig_tp_act_") != -1) {
-		   if (getSelectedElement(selectElements[i]).value == "jstacktrace") {
-                return true;
-           }
+	var selectElements = document.getElementsByTagName("select");
+	for (var i = 0; i < selectElements.length; i++) {
+		if (selectElements[i].id.indexOf("trig_tp_act_") != -1) {
+			if (getSelectedElement(selectElements[i]).value == "jstacktrace") {
+				return true;
+			}
 		}
-    }
+	}
 	return false;
 }
 
 // Returns true if any triggers have an action to start tracing, false otherwise
 // If entryOnly == true, we only return true if the action is defined in an entry action
 function isTriggerResumeActionSelected(entryOnly) {
-    for (var i = 0; i < triggerCounter; i++) {
+	for (var i = 0; i < triggerCounter; i++) {
 		var actionElements = [
-		    document.getElementById("trig_meth_ent_" + i),
+			document.getElementById("trig_meth_ent_" + i),
 			document.getElementById("trig_meth_ex_" + i),
 			document.getElementById("trig_tp_act_" + i),
 			document.getElementById("trig_grp_act_" + i)
-			];
+		];
 		for (var j = 0; j < actionElements.length; j++) {
-		    if (actionElements[j] != null) {
-		        if (getSelectedElement(actionElements[j]).value == "resumethis"
-				    || getSelectedElement(actionElements[j]).value == "resume")
+			if (actionElements[j] != null) {
+				if (getSelectedElement(actionElements[j]).value == "resumethis"
+					|| getSelectedElement(actionElements[j]).value == "resume")
 				{
-    			    if (actionElements[j].id.indexOf("_ex_") != -1 && !entryOnly) {
-					    return true;
+					if (actionElements[j].id.indexOf("_ex_") != -1 && !entryOnly) {
+						return true;
 					} else {
-					    return true;
+						return true;
 					}
-			    }
-		    }
+				}
+			}
 		}
 	}
-	
+
 	// If we reach here we didn't find any resume actions
 	return false;
 }
@@ -1174,9 +1171,9 @@ function isTriggerResumeActionSelected(entryOnly) {
 function isOutputFileSpecified() {
 	var regularOutputElement = document.getElementById("file_text");
 	if (!regularOutputElement.disabled && regularOutputElement.value != "") {
-	    return true;
+		return true;
 	} else {
-	    return false;
+		return false;
 	}
 }
 
@@ -1184,91 +1181,91 @@ function isOutputFileSpecified() {
 function isExceptionOutputFileSpecified() {
 	var exceptionOutputElement = document.getElementById("file_text_exception");
 	if (!exceptionOutputElement.disabled && exceptionOutputElement.value != "") {
-	    return true;
+		return true;
 	} else {
-	    return false;
+		return false;
 	}
 }
 
 // Returns true if at least one tracepoint is enabled, false otherwise
 function isAtLeastOneTracepointEnabled() {
-    var disableDefaultTracepointsElement = document.getElementById("disable_predefined");
+	var disableDefaultTracepointsElement = document.getElementById("disable_predefined");
 	if (disableDefaultTracepointsElement.disabled || !disableDefaultTracepointsElement.checked) {
-	    return true;
+		return true;
 	} else {
-	    for (var i = 0; i < tracepointCounter; i++) {
-            if (document.getElementById("tracepoint_" + i) != null) {
-    		    return true;
-		    }
-	    }
+		for (var i = 0; i < tracepointCounter; i++) {
+			if (document.getElementById("tracepoint_" + i) != null) {
+				return true;
+			}
+		}
 	}
 	return false;
 }  
 
 // Returns true if a "methods" component tracepoint is enabled
 function isMethodTracepointEnabled() {
-    for (var i = 0; i < tracepointCounter; i++) {
-	    var methodsComponentOption = document.getElementById("tp_comp_mt_" + i);
+	for (var i = 0; i < tracepointCounter; i++) {
+		var methodsComponentOption = document.getElementById("tp_comp_mt_" + i);
 		if (methodsComponentOption != null && methodsComponentOption.selected) {
-		    return true;
-    	}
+			return true;
+		}
 	}	
 	return false;
 }
 
 // Returns true if an "all" component tracepoint is enabled
 function isAllTracepointEnabled() {
-    for (var i = 0; i < tracepointCounter; i++) {
-	    var allComponentsOption = document.getElementById("tp_comp_all_" + i);
+	for (var i = 0; i < tracepointCounter; i++) {
+		var allComponentsOption = document.getElementById("tp_comp_all_" + i);
 		if (allComponentsOption != null && allComponentsOption.selected) {
-		    return true;
-    	}
+			return true;
+		}
 	}	
 	return false;
 }
 
 // Returns true if a tracepoint including the specified tracepoint ID is enabled, false otherwise
 function isIdTracepointEnabled(specifiedId) {
-    for (var i = 0; i < tracepointCounter; i++) {
-        tracepointIdElement = document.getElementById("tp_id_" + i);
+	for (var i = 0; i < tracepointCounter; i++) {
+		tracepointIdElement = document.getElementById("tp_id_" + i);
 		if (tracepointIdElement != null) {
-		    // Simple case
+			// Simple case
 			if (tracepointIdElement.value.indexOf(specifiedId) != -1) {
-			    return true;
+				return true;
 			}
-			
+
 			// Deal with ranges
 			var ids = tracepointIdElement.value.split(",");
 			for (var j = 0; j < ids.length; j++) {
-			    if (ids[j].indexOf("-") != -1) {
-				    var regexArray = ids[j].match(/([a-zA-Z0-9]+)\.(\d+)-(\d+)/);
+				if (ids[j].indexOf("-") != -1) {
+					var regexArray = ids[j].match(/([a-zA-Z0-9]+)\.(\d+)-(\d+)/);
 					var component = regexArray[1];
 					var rangeStart = regexArray[2];
-	                var rangeEnd = regexArray[3];
+					var rangeEnd = regexArray[3];
 					if (specifiedId.indexOf("-") == -1) {
-					    // Specified ID is not a range
+						// Specified ID is not a range
 						regexArray = specifiedId.match(/([a-zA-Z0-9]+)\.(\d+)$/);
 						var specifiedComponent = regexArray[1]
 						var specifiedIndex = parseInt(regexArray[2]);
 						if (specifiedComponent == component
-						    && specifiedIndex >= rangeStart
+							&& specifiedIndex >= rangeStart
 							&& specifiedIndex <= rangeEnd)
-					    {
-						    return true;
+						{
+							return true;
 						}					   					
 					} else {
-					    // Specified ID is a range
+						// Specified ID is a range
 						regexArray = specifiedId.match(/([a-zA-Z0-9]+)\.(\d+)-(\d+)/);
 						var specifiedComponent = regexArray[1]
 						var specifiedRangeStart = parseInt(regexArray[2]);
 						var specifiedRangeEnd = parseInt(regexArray[3]);
 						if (specifiedComponent == component
-						    && specifiedRangeStart >= rangeStart
+							&& specifiedRangeStart >= rangeStart
 							&& specifiedRangeStart <= rangeEnd
 							&& specifiedRangeEnd >= rangeStart
 							&& specifiedRangeEnd <= rangeEnd)
 						{
-						    return true;
+							return true;
 						}
 					}
 				}
@@ -1280,21 +1277,21 @@ function isIdTracepointEnabled(specifiedId) {
 
 // Returns true if the "maximal" tracepoint destination is enabled
 function isMaximalTracepointDestinationEnabled() {
-    for (var i = 0; i < tracepointCounter; i++) {
-	    if (document.getElementById("tp_dest_maximal_" + i) != null) { 
+	for (var i = 0; i < tracepointCounter; i++) {
+		if (document.getElementById("tp_dest_maximal_" + i) != null) { 
 			if (document.getElementById("tp_dest_maximal_" + i).selected) {
-		        return true;
-    		}
-        }			
+				return true;
+			}
+		}			
 	}	
 	return false;
 }
 
 // Returns true if a method trace spec has been added, false otherwise
 function isMethodOptionEnabled() {
-    for (var i = 0; i < methodCounter; i++) {
-        if (document.getElementById("method_" + i) != null) {
-		    return true;
+	for (var i = 0; i < methodCounter; i++) {
+        	if (document.getElementById("method_" + i) != null) {
+			return true;
 		}
 	}
 	return false;
@@ -1304,94 +1301,96 @@ function isMethodOptionEnabled() {
 // All VM tracepoint IDs use lower case.
 // IBM JCL tracepoint IDs use upper case.
 function fixTracepointIdCase(id) {
-	var lowercaseIds = [ "j9",
-                         "cuda4j",
-                         "ddrext",
-                         "ifa",
-                         "avl",
-                         "hashtable",
-                         "pool",
-                         "dg",
-                         "mt",
-                         "simplepool",
-                         "map",
-                         "sunvmi",
-                         "gptest",
-                         "module",
-                         "srphashtable" ];
-		
+	var lowercaseIds = [
+		"j9",
+		"cuda4j",
+		"ddrext",
+		"ifa",
+		"avl",
+		"hashtable",
+		"pool",
+		"dg",
+		"mt",
+		"simplepool",
+		"map",
+		"sunvmi",
+		"gptest",
+		"module",
+		"srphashtable"
+	];
+
 	// Check whether we need to use lower case
 	for (var i = 0; i < lowercaseIds.length; i++) {
 		if (id.toLowerCase().lastIndexOf(lowercaseIds[i]) == 0) {
-		    return id.toLowerCase();
+			return id.toLowerCase();
 		}			
 	}
-	
+
 	// If we reach here, use upper case
 	return id.toUpperCase();
 }
 
 function disableInput(inputElement) {
-    // Disable the input itself
+	// Disable the input itself
 	inputElement.disabled = true;	
-	
+
 	// Disable associated labels, if any
 	var labelElements = getLabelsForInput(inputElement);
 	if (typeof labelElements != undefined && labelElements != null) {
 		for (var i = 0; i < labelElements.length; i++) {
-	        labelElements[i].setAttribute("data-disabled", "true");
+			labelElements[i].setAttribute("data-disabled", "true");
 		}
 	}
-	
+
 	// Disable associated buttons, if any
 	var buttonElements = getButtonsForInput(inputElement);
 	if (typeof buttonElements != undefined && buttonElements != null) {
 		for (var i = 0; i < buttonElements.length; i++) {
-	        buttonElements[i].disabled = true;
+			buttonElements[i].disabled = true;
 		}
 	}
 }
 
 function enableInput(inputElement) {
-    // Enable the input itself
+	// Enable the input itself
 	inputElement.disabled = false;
-	
+
 	// Enable associated labels, if any
 	var labelElements = getLabelsForInput(inputElement);
 	if (typeof labelElements != undefined && labelElements != null) {
-	    for (var i = 0; i < labelElements.length; i++) {
-    	    labelElements[i].setAttribute("data-disabled", "false");
+		for (var i = 0; i < labelElements.length; i++) {
+			labelElements[i].setAttribute("data-disabled", "false");
 		}
-    }
-	
+	}
+
 	// Enable associated buttons, if any
 	var buttonElements = getButtonsForInput(inputElement);
 	if (typeof buttonElements != undefined && buttonElements != null) {
 		for (var i = 0; i < buttonElements.length; i++) {
-	        buttonElements[i].disabled = false;
+			buttonElements[i].disabled = false;
 		}
 	}
 }
 
 function getLabelsForInput(inputElement) {
-    var allLabels = document.getElementsByTagName("label");
-    var results = [];
-    for (var i = 0; i < allLabels.length; i++) {
-        if (inputElement.id == allLabels[i].htmlFor) {
-		    results.push(allLabels[i]);
+	var allLabels = document.getElementsByTagName("label");
+	var results = [];
+	for (var i = 0; i < allLabels.length; i++) {
+		if (inputElement.id == allLabels[i].htmlFor) {
+			results.push(allLabels[i]);
 		}
-    }
+	}
 	return results;
 }
 
 function getButtonsForInput(inputElement) {
-    var allInputs = document.getElementsByTagName("input");
-    var results = [];
-    for (var i = 0; i < allInputs.length; i++) {
-        if (allInputs[i].type == "button"
-		    && allInputs[i].getAttribute("data-target") == inputElement.id)
+	var allInputs = document.getElementsByTagName("input");
+	var results = [];
+	for (var i = 0; i < allInputs.length; i++) {
+		if (allInputs[i].type == "button"
+			&& allInputs[i].getAttribute("data-target") == inputElement.id)
 		{
-		    results.push(allInputs[i]);
+			results.push(allInputs[i]);
 		}
 	}
 	return results;
@@ -1399,19 +1398,19 @@ function getButtonsForInput(inputElement) {
 
 // If a string ends with a ',' remove it
 function removeFinalCommaIfPresent(string) {
-    if (string.length > 0 && string.lastIndexOf(",") == string.length - 1) {
-	    return string.slice(0, -1);
+	if (string.length > 0 && string.lastIndexOf(",") == string.length - 1) {
+		return string.slice(0, -1);
 	} else {
-	    return string;
+		return string;
 	}	
 }
 
 // If a string ends with a '&' remove it
 function removeFinalAmpersandIfPresent(string) {
-    if (string.length > 0 && string.lastIndexOf("&") == string.length - 1) {
-	    return string.slice(0, -1);
+	if (string.length > 0 && string.lastIndexOf("&") == string.length - 1) {
+		return string.slice(0, -1);
 	} else {
-	    return string;
+		return string;
 	}
 }
 
@@ -1423,82 +1422,82 @@ function findInvalidTracepointSpecs(value) {
 	var specs = value.split(",");
 	var invalidSpecs = "";
 	for (var i = 0; i < specs.length; i++) {
-	    if (specs[i] == "") {
-		    invalidSpecs += "ERROR: Empty tracepoint specification<br>";
+		if (specs[i] == "") {
+			invalidSpecs += "ERROR: Empty tracepoint specification<br>";
 		} else {
-		    if (specs[i].match(/^([a-zA-Z0-9])+\.\d+(-\d+)?$/) == null) {
-        	    invalidSpecs += "ERROR: Invalid tracepoint specification: \"" + specs[i] + "\"<br>";
-		    }
-	    }
+			if (specs[i].match(/^([a-zA-Z0-9])+\.\d+(-\d+)?$/) == null) {
+				invalidSpecs += "ERROR: Invalid tracepoint specification: \"" + specs[i] + "\"<br>";
+			}
+		}
 	}
 	return invalidSpecs; 
 }
 
 function buildAndUpdateResult() {
-    var resultString = "-Xtrace:";	
-	
+	var resultString = "-Xtrace:";	
+
 	// Disable predefined (default) tracepoints?
 	var disableDefaultTracepointsElement = document.getElementById("disable_predefined");
 	if (!disableDefaultTracepointsElement.disabled && disableDefaultTracepointsElement.checked) {
-	    resultString += "none,";	
+		resultString += "none,";	
 	}
-	
+
 	// Add tracepoints
 	var tracepointString = getTracepointResultString()
 	if (tracepointString != "") {
-	    resultString += tracepointString + ",";
+		resultString += tracepointString + ",";
 	}
-	
+
 	// Add methods
 	var methodString = getMethodResultString();
 	if (methodString != "") {
-	    resultString += methodString + ",";
+		resultString += methodString + ",";
 	}
-	
+
 	// Add triggers
 	var triggerString = getTriggerResultString();
 	if (triggerString != "") {
-	    resultString += triggerString + ",";
+		resultString += triggerString + ",";
 	}
-	
+
 	// Add output and/or exception.output
 	var outputString = getOutputResultString();
 	if (outputString != "") {
-	    resultString += outputString;
+		resultString += outputString;
 	}
-	
+
 	// If the string ends with a ',' remove it
 	resultString = removeFinalCommaIfPresent(resultString);
-	
+
 	// Wrap in quotes if option checked
 	// TODO: This doesn't work properly on Linux if there is an '!' in a method/tpnid field
 	//       Single quotes don't work on Windows...
 	if (document.getElementById("wrap_in_quotes").checked) {
-	    // Then wrap the entire result string in quotes
+		// Then wrap the entire result string in quotes
 		resultString = "\"" + resultString + "\"";
 	}
-			
+
 	// Escape HTML
 	resultString = escapeHTML(resultString);
-	
+
 	// Add <wbr> tags after '+', ','. '/' and '=' characters
 	// to make the wrapping prettier for longer options
 	resultString = resultString.replace(/,/g, ",<wbr>");
 	resultString = resultString.replace(/\+/g, "+<wbr>");
 	resultString = resultString.replace(/\//g, "/<wbr>");
 	resultString = resultString.replace(/=/g, "=<wbr>");
-	
+
 	// Initialize variables for error checking
 	var resultIsGreen = true;
 	var errorsHtml = "";
 	var warningsHtml = "";
-	
+
 	// Check whether any tracepoints/methods/triggers are present
 	var inputPresent = false;
 	var maxCounter = Math.max(tracepointCounter, Math.max(methodCounter, triggerCounter));
 	for (var i = 0; i < maxCounter; i++) {
-	    if (   document.getElementById("tracepoint_" + i) != null
-		    || document.getElementById("method_" + i) != null
+		if (document.getElementById("tracepoint_" + i) != null
+			|| document.getElementById("method_" + i) != null
 			|| document.getElementById("trigger_" + i) != null)
 		{
 			inputPresent = true;
@@ -1506,630 +1505,630 @@ function buildAndUpdateResult() {
 		}
 	}
 	if (!inputPresent) {
-	    resultIsGreen = false;
+		resultIsGreen = false;
 		errorsHtml += "ERROR: No tracepoints/methods/triggers have been specified<br>";
 	}
-	
+
 	// Check that the mt tracepoint is enabled if a jstacktrace method trigger action is enabled
 	if (   isMethodJStackTraceActionSelected()
-	    && !isMethodTracepointEnabled()
+		&& !isMethodTracepointEnabled()
 		&& !isAllTracepointEnabled() )
 	{
-	    resultIsGreen = false;
+		resultIsGreen = false;
 		errorsHtml += "ERROR: A jstacktrace method trigger action has been enabled but the \"Methods\" tracepoint has not been enabled. Stacks will not be traced.<br>";
 	}
-	
+
 	// Check that a method trace or jstacktrace method trigger action is defined if an mt tracepoint is enabled
 	if (   isMethodTracepointEnabled()
-	    && !isMethodOptionEnabled()
+		&& !isMethodOptionEnabled()
 		&& !isMethodJStackTraceActionSelected() )
 	{
-	    resultIsGreen = false;
+		resultIsGreen = false;
 		errorsHtml += "ERROR: \"Methods\" component tracepoint is enabled but no methods have been specified for tracing, and no jstacktrace method trigger actions have been enabled<br>";
 	}
-	
+
 	// Check that each method option actually contains a method spec
 	for (var i = 0; i < methodCounter; i++) {
-        var methodSpecElement = document.getElementById("meth_text_" + i);
+		var methodSpecElement = document.getElementById("meth_text_" + i);
 		if (methodSpecElement != null) {
-            if (methodSpecElement.value == "") {
-                resultIsGreen = false;
-			    setErrorStyle(methodSpecElement);
-			    errorsHtml += "ERROR: Missing method specification in method trace<br>";
-		    } else {
-    		    unsetErrorStyle(methodSpecElement);
-		    }
-		}
-    }
-	
-	// Check that each ID tracepoint has a tpnid
-	for (var i = 0; i < tracepointCounter; i++) {
-        var tracepointIdElement = document.getElementById("tp_id_" + i);
-		if (tracepointIdElement != null) {
-		    var invalidSpecs = findInvalidTracepointSpecs(tracepointIdElement.value);
-			if (invalidSpecs != "") {
-			    resultIsGreen = false;
-			    setErrorStyle(tracepointIdElement);
-			    errorsHtml += invalidSpecs;
+			if (methodSpecElement.value == "") {
+				resultIsGreen = false;
+				setErrorStyle(methodSpecElement);
+				errorsHtml += "ERROR: Missing method specification in method trace<br>";
 			} else {
-			    unsetErrorStyle(tracepointIdElement);
+				unsetErrorStyle(methodSpecElement);
 			}
 		}
-    }
-	
+	}
+
+	// Check that each ID tracepoint has a tpnid
+	for (var i = 0; i < tracepointCounter; i++) {
+		var tracepointIdElement = document.getElementById("tp_id_" + i);
+		if (tracepointIdElement != null) {
+			var invalidSpecs = findInvalidTracepointSpecs(tracepointIdElement.value);
+			if (invalidSpecs != "") {
+				resultIsGreen = false;
+				setErrorStyle(tracepointIdElement);
+				errorsHtml += invalidSpecs;
+			} else {
+				unsetErrorStyle(tracepointIdElement);
+			}
+		}
+	}
+
 	// Trigger checks
 	var resumeSelectedEntry = false;
 	var resumeSelectedExit = false;
 	for (var i = 0; i < triggerCounter; i++) {
-        // Method trigger checks
+        	// Method trigger checks
 		var methodSpecElement = document.getElementById("trig_meth_spec_" + i);
 		if (methodSpecElement != null) {
-            // Check whether a method spec is provided
+			// Check whether a method spec is provided
 			if (methodSpecElement.value == "") {
-                resultIsGreen = false;
+				resultIsGreen = false;
 				setErrorStyle(methodSpecElement);
-			    errorsHtml += "ERROR: Missing method specification in trigger<br>";
+				errorsHtml += "ERROR: Missing method specification in trigger<br>";
 			} else {
-			    // Method spec is present
+				// Method spec is present
 				unsetErrorStyle(methodSpecElement);
 				
 				// Check that an entry or exit action is provided
-			    var entryActionElement = getSelectedElement(document.getElementById("trig_meth_ent_" + i));
+				var entryActionElement = getSelectedElement(document.getElementById("trig_meth_ent_" + i));
 				var exitActionElement = getSelectedElement(document.getElementById("trig_meth_ex_" + i));
 				if (entryActionElement.value == "none" && exitActionElement.value == "none") {
-			        resultIsGreen = false;
-				    setErrorStyle(entryActionElement);
+			        	resultIsGreen = false;
+					setErrorStyle(entryActionElement);
 					setErrorStyle(exitActionElement);
 					errorsHtml += "ERROR: No entry/exit action selected for method trigger: " + methodSpecElement.value + "<br>";
 				} else {
-				    unsetErrorStyle(entryActionElement);
+					unsetErrorStyle(entryActionElement);
 					unsetErrorStyle(exitActionElement);
 				}
-            }
+			}
 		}
-		
+
 		// Tracepoint trigger checks
 		var tracepointIdElement = document.getElementById("trig_tp_tpnid_" + i);
 		if (tracepointIdElement != null) {
-		    var tracepointActionElement = getSelectedElement(document.getElementById("trig_tp_act_" + i));
-		    if (tracepointIdElement.value == "") {
-                resultIsGreen = false;
-			    setErrorStyle(tracepointIdElement);
-			    errorsHtml += "ERROR: Missing tracepoint ID in trigger<br>";
-		    } else if (tracepointIdElement.value.indexOf(",") != -1) {
-			    resultIsGreen = false;
-			    setErrorStyle(tracepointIdElement);
-			    errorsHtml += "ERROR: Trigger tracepoint ID field contains multiple IDs. Only one tracepoint ID or range of tracepoint IDs is allowed per trigger.<br>";
+			var tracepointActionElement = getSelectedElement(document.getElementById("trig_tp_act_" + i));
+			if (tracepointIdElement.value == "") {
+				resultIsGreen = false;
+				setErrorStyle(tracepointIdElement);
+				errorsHtml += "ERROR: Missing tracepoint ID in trigger<br>";
+			} else if (tracepointIdElement.value.indexOf(",") != -1) {
+				resultIsGreen = false;
+				setErrorStyle(tracepointIdElement);
+				errorsHtml += "ERROR: Trigger tracepoint ID field contains multiple IDs. Only one tracepoint ID or range of tracepoint IDs is allowed per trigger.<br>";
 			} else if (findInvalidTracepointSpecs(tracepointIdElement.value) != "") {
-			    resultIsGreen = false;
-			    setErrorStyle(tracepointIdElement);
-			    errorsHtml += findInvalidTracepointSpecs(tracepointIdElement.value);
+				resultIsGreen = false;
+				setErrorStyle(tracepointIdElement);
+				errorsHtml += findInvalidTracepointSpecs(tracepointIdElement.value);
 			} else if (tracepointActionElement.value == "jstacktrace" && !isIdTracepointEnabled(tracepointIdElement.value)) {
 				resultIsGreen = false;
-			    setErrorStyle(tracepointIdElement);
-			    errorsHtml += "ERROR: A jstacktrace tracepoint trigger action has been enabled but the specified tracepoint ID is not being traced. Stacks will not be traced.<br>";
+				setErrorStyle(tracepointIdElement);
+				errorsHtml += "ERROR: A jstacktrace tracepoint trigger action has been enabled but the specified tracepoint ID is not being traced. Stacks will not be traced.<br>";
 			} else {
-    		    unsetErrorStyle(tracepointIdElement);
-		    }
-			
+				unsetErrorStyle(tracepointIdElement);
+			}
+
 			if (tracepointActionElement.value == "none") {
-			    resultIsGreen = false;
+				resultIsGreen = false;
 				setErrorStyle(tracepointActionElement);
 				errorsHtml += "ERROR: No action selected for tracepoint trigger: " + tracepointIdElement.value + "<br>";
 			} else {
-    		    unsetErrorStyle(tracepointActionElement);
-		    }
+				unsetErrorStyle(tracepointActionElement);
+			}
 		}
-		
+
 		// Check validity of delay value
 		var delayElement = document.getElementById("trig_delay_" + triggerCounter);
-	    if (delayElement != null) {
-            if (delayElement.value < 0) {
-		        resultIsGreen = false;
-			    setErrorStyle(delayElement);
-			    errorsHtml += "ERROR: Invalid trigger delay (" + delayElement.value + "): must be >= 0.<br>";	
-		    } else {
-			    unsetErrorStyle(delayElement);
+		if (delayElement != null) {
+			if (delayElement.value < 0) {
+				resultIsGreen = false;
+				setErrorStyle(delayElement);
+				errorsHtml += "ERROR: Invalid trigger delay (" + delayElement.value + "): must be >= 0.<br>";	
+			} else {
+				unsetErrorStyle(delayElement);
 			}
 		}
-		
+
 		// Check validity of limit/match value
 		var matchElement = document.getElementById("trig_match_" + triggerCounter);
-	    if (matchElement != null) {
-            if (matchElement.value < 0) {
-		        resultIsGreen = false;
-			    setErrorStyle(matchElement);
+		if (matchElement != null) {
+			if (matchElement.value < 0) {
+				resultIsGreen = false;
+				setErrorStyle(matchElement);
 				errorsHtml += "ERROR: Invalid trigger limit (" + matchElement.value + "): must be >= 0.<br>";	
-		    } else {
-			    unsetErrorStyle(matchElement);
+			} else {
+				unsetErrorStyle(matchElement);
 			}
 		}
 	}
-	
+
 	// If any triggers have an entry action to start tracing, check:
-    //    1. Whether trace is initially disabled
+	//    1. Whether trace is initially disabled
 	//    2. Whether any tracepoints are enabled
 	if (isTriggerResumeActionSelected(true)) {
-	    if (isAtLeastOneTracepointEnabled()) {
-            if (!document.getElementById("trace_initially_disabled").checked) {
-	            errorsHtml += "WARNING: A trigger (entry) action is set to start tracing, but tracing is already enabled. Did you mean to check the \"Trace initially stopped\" option?<br>";
+		if (isAtLeastOneTracepointEnabled()) {
+			if (!document.getElementById("trace_initially_disabled").checked) {
+				errorsHtml += "WARNING: A trigger (entry) action is set to start tracing, but tracing is already enabled. Did you mean to check the \"Trace initially stopped\" option?<br>";
 			}
 		} else {
-	        resultIsGreen = false;
-		    errorsHtml += "ERROR: A trigger (entry) action is set to start tracing, but no tracepoints are enabled<br>";
-	    }
+			resultIsGreen = false;
+			errorsHtml += "ERROR: A trigger (entry) action is set to start tracing, but no tracepoints are enabled<br>";
+		}
 	}
-	
+
 	// If no triggers have an action to start tracing, check that "Trace initially stopped" is not selected
 	if (!isTriggerResumeActionSelected(false)) {
-	    if (isAtLeastOneTracepointEnabled()) {
-            if (document.getElementById("trace_initially_disabled").checked) {
-	            errorsHtml += "WARNING: \"Trace initially stopped\" is selected, but no trigger actions enable tracing. No trace will be produced.<br>";
+		if (isAtLeastOneTracepointEnabled()) {
+			if (document.getElementById("trace_initially_disabled").checked) {
+				errorsHtml += "WARNING: \"Trace initially stopped\" is selected, but no trigger actions enable tracing. No trace will be produced.<br>";
 			}
 		}	    
 	}	
-	
-    // Check output file fields
+
+    	// Check output file fields
 	var fileTextElement = document.getElementById("file_text");
 	if (!fileTextElement.disabled) {
-	    if (!isOutputFileSpecified()) {
-		    // Warning only - output file is not manadatory
-		    warningsHtml += "WARNING: No output file specified for trace buffers (trace will still be visible in snap dumps)<br>";
+		if (!isOutputFileSpecified()) {
+			// Warning only - output file is not manadatory
+			warningsHtml += "WARNING: No output file specified for trace buffers (trace will still be visible in snap dumps)<br>";
 		} else if (containsReservedChars(fileTextElement.value)) {
-		    warningsHtml += "WARNING: Trace buffer output file contains a character that is disallowed on some platforms<br>";
+			warningsHtml += "WARNING: Trace buffer output file contains a character that is disallowed on some platforms<br>";
 		}
 	}
 	var exceptionFileTextElement = document.getElementById("file_text_exception");
 	if (!exceptionFileTextElement.disabled) {
-	    if (!isExceptionOutputFileSpecified()) {
-		    // Exception output *is* mandatory if enabled
-		    resultIsGreen = false;
-		    setErrorStyle(exceptionFileTextElement);
-		    errorsHtml += "ERROR: No output file specified for Exception trace buffers<br>";	
+		if (!isExceptionOutputFileSpecified()) {
+			// Exception output *is* mandatory if enabled
+			resultIsGreen = false;
+			setErrorStyle(exceptionFileTextElement);
+			errorsHtml += "ERROR: No output file specified for Exception trace buffers<br>";	
 		} else {
-	        unsetErrorStyle(exceptionFileTextElement);
-	    }
-		
+			unsetErrorStyle(exceptionFileTextElement);
+		}
+
 		if (containsReservedChars(exceptionFileTextElement.value)) {
-		    warningsHtml += "WARNING: Exception trace buffer output file contains a character that is disallowed on some platforms<br>";		
+			warningsHtml += "WARNING: Exception trace buffer output file contains a character that is disallowed on some platforms<br>";		
 		}
 	} else {
-	    unsetErrorStyle(exceptionFileTextElement);
+		unsetErrorStyle(exceptionFileTextElement);
 	}
-	
+
 	// Output file checks when generations > 1 
 	var generationsElement = document.getElementById("output_generations");
 	var fileElement = document.getElementById("file_text");
 	var fileString = fileElement.value;
-	if (   fileString != ""
-	    && !generationsElement.disabled
+	if (fileString != ""
+		&& !generationsElement.disabled
 		&& generationsElement.value > 1)
 	{
-	    // Check that '#' token is present in output file text when generations > 1
+		// Check that '#' token is present in output file text when generations > 1
 		if (fileString.indexOf("#") == -1) {
-    	    resultIsGreen = false;
-		    setErrorStyle(fileElement);
+			resultIsGreen = false;
+			setErrorStyle(fileElement);
 			errorsHtml += "ERROR: Maximum number of output files is > 1, but the File Counter token ('#') is missing from the output file name<br>";	
 		} else {
-		    unsetErrorStyle(fileElement);
+			unsetErrorStyle(fileElement);
 		}
 		// Check that only one '#' token is present
 		if (fileString.indexOf("#") != fileString.lastIndexOf("#")) {
-    	    warningsHtml += "WARNING: There are two '#' tokens in the output file field. Only the first token will be replaced by the file counter.<br>";	
+			warningsHtml += "WARNING: There are two '#' tokens in the output file field. Only the first token will be replaced by the file counter.<br>";	
 		}		
 		// Check that the max file size is > 0
 		var outputSizeElement = document.getElementById("output_size");
 		if (outputSizeElement.value == 0) {
-    	    warningsHtml += "WARNING: Maximum number of output files is > 1, but the maximum file size is set to 0<br>";	
+			warningsHtml += "WARNING: Maximum number of output files is > 1, but the maximum file size is set to 0<br>";	
 		} else {
-		    unsetErrorStyle(outputSizeElement);
+			unsetErrorStyle(outputSizeElement);
 		}
 	}
 
-    // Check remaining number field values (trigger number fields have already been checked)
-    if (generationsElement.value < 1 || generationsElement.value > 36) {
-	    resultIsGreen = false;
+	// Check remaining number field values (trigger number fields have already been checked)
+	if (generationsElement.value < 1 || generationsElement.value > 36) {
+		resultIsGreen = false;
 		setErrorStyle(generationsElement);
 		errorsHtml += "ERROR: Invalid maximum number of output files (" + generationsElement.value + "): valid range is 1-36.<br>";	
 	} else {
-	    unsetErrorStyle(generationsElement);
+		unsetErrorStyle(generationsElement);
 	}
 	var outputSizeElement = document.getElementById("output_size");
-    if (outputSizeElement.value < 0) {
-	    resultIsGreen = false;
+	if (outputSizeElement.value < 0) {
+		resultIsGreen = false;
 		setErrorStyle(outputSizeElement);
 		errorsHtml += "ERROR: Invalid maximum output file size (" + outputSizeElement.value + "): must be > 0, or 0 to set no limit.<br>";	
 	} else {
 	    unsetErrorStyle(outputSizeElement);
 	}
-    var outputSizeExceptionElement = document.getElementById("output_size_exception");
-    if (!outputSizeExceptionElement.disabled && outputSizeExceptionElement.value < 0) {
-	    resultIsGreen = false;
+	var outputSizeExceptionElement = document.getElementById("output_size_exception");
+	if (!outputSizeExceptionElement.disabled && outputSizeExceptionElement.value < 0) {
+		resultIsGreen = false;
 		setErrorStyle(outputSizeExceptionElement);
 		errorsHtml += "ERROR: Invalid maximum Exception output file size (" + outputSizeExceptionElement.value + ") is invalid: must be > 0, or 0 to set no limit.<br>";	
 	} else {
-	    unsetErrorStyle(outputSizeExceptionElement);
+		unsetErrorStyle(outputSizeExceptionElement);
 	}
 	var sleepTimeElement = document.getElementById("sleep_time");
-    if (!sleepTimeElement.disabled && sleepTimeElement.value <= 0) {
-	    resultIsGreen = false;
+	if (!sleepTimeElement.disabled && sleepTimeElement.value <= 0) {
+		resultIsGreen = false;
 		setErrorStyle(sleepTimeElement);
 		errorsHtml += "ERROR: Invalid sleep time (" + sleepTimeElement.value + "): must be > 0.<br>";	
 	} else {
-	    unsetErrorStyle(sleepTimeElement);
+		unsetErrorStyle(sleepTimeElement);
 	}
 	var bufferSizeElement = document.getElementById("buffer_size");
-    if (bufferSizeElement.value <= 0) {
-	    resultIsGreen = false;
+	if (bufferSizeElement.value <= 0) {
+		resultIsGreen = false;
 		setErrorStyle(bufferSizeElement);
 		errorsHtml += "ERROR: Invalid trace buffer size (" + bufferSizeElement.value + "): must be > 0.<br>";	
 	} else {
-	    unsetErrorStyle(bufferSizeElement);
+		unsetErrorStyle(bufferSizeElement);
 	}
 	var stackDepthElement = document.getElementById("stack_depth");
-    if (stackDepthElement.value < 0) {
-	    resultIsGreen = false;
+	if (stackDepthElement.value < 0) {
+		resultIsGreen = false;
 		setErrorStyle(stackDepthElement);
 		errorsHtml += "ERROR: Invalid stack depth (" + stackDepthElement.value + "): must be > 0, or 0 to set no limit.<br>";	
 	} else {
-	    unsetErrorStyle(stackDepthElement);
+		unsetErrorStyle(stackDepthElement);
 	}
-		
+
 	// Add the result string in the appropriate colour
 	if (resultIsGreen) {
-	    document.getElementById("result").innerHTML = "<font color=\"green\">" + resultString + "</font>";
+		document.getElementById("result").innerHTML = "<font color=\"green\">" + resultString + "</font>";
 	} else {
 		document.getElementById("result").innerHTML = "<font color=\"red\">" + resultString + "</font>";
 	}
-	
+
 	// Add errors/warnings, if any
 	if (errorsHtml != "" || warningsHtml != "") { 
-	    document.getElementById("errors").innerHTML = errorsHtml + warningsHtml;
+		document.getElementById("errors").innerHTML = errorsHtml + warningsHtml;
 	} else {
-	    document.getElementById("errors").innerHTML = "&nbsp;";
+		document.getElementById("errors").innerHTML = "&nbsp;";
 	}
 }
 
 function getTracepointResultString() {
-    // Cycle through tracepoints <li> elements, format the contents
-    // and add them to a comma-separated string
+	// Cycle through tracepoints <li> elements, format the contents
+	// and add them to a comma-separated string
 	var destinationStrings = {};
 	var destinationCount = {};
 	var tracepointString = "";
 	for (var i = 0; i < tracepointCounter; i++) {
-	    var tracepointListElement = document.getElementById("tracepoint_" + i);
-		       
+		var tracepointListElement = document.getElementById("tracepoint_" + i);
+
 		if (tracepointListElement != null) {
-		    var destination = getSelectedElement(document.getElementById("tp_dest_select_" + i)).value;
-			
+			var destination = getSelectedElement(document.getElementById("tp_dest_select_" + i)).value;
+
 			if (typeof destinationStrings != undefined && destination in destinationStrings) {
-			    destinationCount[destination]++;
+				destinationCount[destination]++;
 			} else {
-                destinationCount[destination] = 1;
+				destinationCount[destination] = 1;
 				destinationStrings[destination] = "";
-            }
-			
+			}
+
 			switch (tracepointListElement.getAttribute("data-type")) {
-			    case "id":
-				    // [!]<tracepoint_id>[,<tracepoint_id>]
-				    var tracepointId = document.getElementById("tp_id_" + i).value;
+				case "id":
+					// [!]<tracepoint_id>[,<tracepoint_id>]
+					var tracepointId = document.getElementById("tp_id_" + i).value;
 					destinationStrings[destination] += tracepointId + ",";					
 					break;
-				
+
 				case "component":
-				    // [!]<component>[{<group>}] or [!]<component>[{<type>}]
+					// [!]<component>[{<group>}] or [!]<component>[{<type>}]
 					var component = getSelectedElement(document.getElementById("tp_comp_select_" + i)).value;
 					destinationStrings[destination] += component;					
-					
+
 					var level = getSelectedElement(document.getElementById("tp_level_select_" + i)).value;
 					if (level != 9) {
-					    destinationStrings[destination] += "{L" + level + "}";
+						destinationStrings[destination] += "{L" + level + "}";
 					}
-					
+
 					if (document.getElementById("tp_type_" + i).checked) {
-					    var type = getSelectedElement(document.getElementById("tp_type_select_" + i)).value;
+						var type = getSelectedElement(document.getElementById("tp_type_select_" + i)).value;
 						if (type != "all") {
-						    destinationStrings[destination] += "{" + type + "}";
+							destinationStrings[destination] += "{" + type + "}";
 						}
 						destinationStrings[destination] += ",";
 					}
-					
+
 					if (document.getElementById("tp_group_" + i).checked) {
-					    var group = getSelectedElement(document.getElementById("tp_group_select_" + i)).value;
+						var group = getSelectedElement(document.getElementById("tp_group_select_" + i)).value;
 						if (group != "all") {
-						    destinationStrings[destination] += "{" + group + "}";
+							destinationStrings[destination] += "{" + group + "}";
 						}
 						destinationStrings[destination] += ",";
 					}
-					
+
 					break;
 			}		
 		}
 	}
-	
+
 	// Combine the tracepoint strings for each destination
 	// And add curly braces if necessary
 	for (var destination in destinationStrings) {
-	    tracepointString += destination + "=";
+		tracepointString += destination + "=";
 		destinationStrings[destination] = removeFinalCommaIfPresent(destinationStrings[destination]);
 		if (destinationCount[destination] > 1 || destinationStrings[destination].indexOf(",") != -1) {
-		    tracepointString += "{" + destinationStrings[destination] + "},"; 
+			tracepointString += "{" + destinationStrings[destination] + "},"; 
 		} else {
- 		    tracepointString += destinationStrings[destination] + ",";
+ 			tracepointString += destinationStrings[destination] + ",";
 		}
 	}
-	
+
 	return removeFinalCommaIfPresent(tracepointString);
 }
 
 function getMethodResultString() {
-    // Cycle through methods and add them to a comma-separate string
+	// Cycle through methods and add them to a comma-separate string
 	var methodOptionPresent = false;
 	var methodString = "";
 	for (var i = 0; i < methodCounter; i++) {
-	    var methodListElement = document.getElementById("method_" + i);
+		var methodListElement = document.getElementById("method_" + i);
 		if (methodListElement != null) {
-		    methodOptionPresent = true;
+			methodOptionPresent = true;
 			var methodTextValue = document.getElementById("meth_text_" + i).value;
 			if (methodTextValue != "") {
 				methodString += methodTextValue;
-			    if (document.getElementById("meth_args_" + i).checked) {
-			        methodString += "()";
-			    }
-			    methodString += ",";
+				if (document.getElementById("meth_args_" + i).checked) {
+					methodString += "()";
+				}
+				methodString += ",";
 			}
 		}
-    }
-	
+	}
+
 	methodString = removeFinalCommaIfPresent(methodString);
-	
+
 	// If there's more than one method we need to enclose the list in curly braces
 	if (methodString.indexOf(",") != -1) {
-	   methodString = "{" + methodString + "}";
+		methodString = "{" + methodString + "}";
 	}
-	
+
 	// Add "methods=" prefix
 	if (methodOptionPresent) {
-	    methodString = "methods=" + methodString;
+		methodString = "methods=" + methodString;
 	}
-	
+
 	return methodString;
 }
 
 function getTriggerResultString() {
-    var triggerString = "";
+	var triggerString = "";
 	var sleepActionSelected = false;
-	
+
 	// Trace initially stopped/disabled?
 	if (document.getElementById("trace_initially_disabled").checked) {
-	    triggerString += "resumecount=1,";
+		triggerString += "resumecount=1,";
 	}
-	
+
 	for (var i = 0; i < triggerCounter; i++) {
-	    var triggerListElement = document.getElementById("trigger_" + i);
+		var triggerListElement = document.getElementById("trigger_" + i);
 		if (triggerListElement != null) {
-		    switch (triggerListElement.getAttribute("data-type")) {
-			    case "method":
-				    // trigger=method{<methodspec>[,<entryAction>[,<exitAction>[,<delayCount>[,<matchcount>]]]]}
-					
+			switch (triggerListElement.getAttribute("data-type")) {
+				case "method":
+					// trigger=method{<methodspec>[,<entryAction>[,<exitAction>[,<delayCount>[,<matchcount>]]]]}
+
 					// Method
 					triggerString += "trigger=method{";
 					var methodSpecString = document.getElementById("trig_meth_spec_" + i).value;
 					if (methodSpecString != "") {
-					    triggerString += methodSpecString;
+						triggerString += methodSpecString;
 					}
 					triggerString += ",";
-					
+
 					// Entry action
 					var entryActionString = getSelectedElement(document.getElementById("trig_meth_ent_" + i)).value;
 					if (entryActionString != "none") {
-					    triggerString += entryActionString;
+						triggerString += entryActionString;
 					}
 					triggerString += ",";
-					
+
 					// Exit action
 					var exitActionString = getSelectedElement(document.getElementById("trig_meth_ex_" + i)).value;
 					if (exitActionString != "none") {
-					    triggerString += exitActionString;
+						triggerString += exitActionString;
 					}
 					triggerString += ",";
-					
+
 					// Thread sleep selected?
 					if (entryActionString == "sleep" || exitActionString == "sleep") {
 						sleepActionSelected = true;
 					}
-					
+
 					break;
-				
+
 				case "tracepoint":
-				    // trigger=tpnid{<tpnid>|<tpnidRange>,<action>[,<delayCount>[,<matchcount>]]}
-					
+					// trigger=tpnid{<tpnid>|<tpnidRange>,<action>[,<delayCount>[,<matchcount>]]}
+
 					// tpnid
 					triggerString += "trigger=tpnid{";
-                    var tracepointTpnidString = document.getElementById("trig_tp_tpnid_" + i).value;
+					var tracepointTpnidString = document.getElementById("trig_tp_tpnid_" + i).value;
 					if (tracepointTpnidString != "") {
-					    triggerString += tracepointTpnidString;
+						triggerString += tracepointTpnidString;
 					}
 					triggerString += ",";
-					
+
 					// Action
 					var actionString = getSelectedElement(document.getElementById("trig_tp_act_" + i)).value;
 					if (actionString != "none") {
-					    triggerString += actionString;
+						triggerString += actionString;
 					}
 					triggerString += ",";
-					
+
 					// Thread sleep selected?
 					if (actionString == "sleep") {
 						sleepActionSelected = true;
 					}
-					
+
 					break;
-				
+
 				case "group":
-				    // trigger=group{<groupname>,<action>[,<delayCount>[,<matchcount>]]}
-					
+					// trigger=group{<groupname>,<action>[,<delayCount>[,<matchcount>]]}
+
 					// Group name
 					var groupNameString = getSelectedElement(document.getElementById("trig_grp_name_" + i)).value;
 					triggerString += "trigger=group{";
 					triggerString += groupNameString + ",";
-										
+
 					// Action
 					var actionString = getSelectedElement(document.getElementById("trig_grp_act_" + i)).value;
 					if (actionString != "none") {
-					    triggerString += actionString;
+						triggerString += actionString;
 					}
 					triggerString += ",";
-					
-                    // Thread sleep selected?
+
+					// Thread sleep selected?
 					if (actionString == "sleep") {
 						sleepActionSelected = true;
 					}
-					
+
 					break;		
 			}
-			
+
 			// Delay
 			var delayCountValue = document.getElementById("trig_delay_" + i).value;
 			if (delayCountValue != 0) {
-			    triggerString += delayCountValue;
+				triggerString += delayCountValue;
 			}
 			triggerString += ",";
-					
+
 			// Match / limit
 			var matchCountValue = document.getElementById("trig_match_" + i).value;
 			if (matchCountValue != 0) {
-			    triggerString += matchCountValue;
+				triggerString += matchCountValue;
 			}
 			triggerString += ",";
-			
-            // Remove all trailing commas (we might have a few, depending on which options were specified)
-	        while (triggerString.length > 0 && triggerString.lastIndexOf(",") == triggerString.length - 1) {
-			    triggerString = removeFinalCommaIfPresent(triggerString);
+
+			// Remove all trailing commas (we might have a few, depending on which options were specified)
+			while (triggerString.length > 0 && triggerString.lastIndexOf(",") == triggerString.length - 1) {
+				triggerString = removeFinalCommaIfPresent(triggerString);
 			}			
-					
+
 			// Close the curly braces and add a comma
 			triggerString += "},";
 		}
-    }
-	
+	}
+
 	// Sleep time
 	if (sleepActionSelected) {
-	    triggerString += "sleeptime=" + document.getElementById("sleep_time").value + ",";		
+		triggerString += "sleeptime=" + document.getElementById("sleep_time").value + ",";		
 	}
-	
+
 	// Stack depth
 	var stackDepthElement = document.getElementById("stack_depth");
 	if (!stackDepthElement.disabled && stackDepthElement.value > 0) {
-	    triggerString += "stackdepth=" + stackDepthElement.value;		
+		triggerString += "stackdepth=" + stackDepthElement.value;		
 	}
-	
+
 	return removeFinalCommaIfPresent(triggerString);
 }
 
 function getOutputResultString() {
-    var outputString = "";
-	
+	var outputString = "";
+
 	var buffersString = "";
-	
+
 	// Buffer size
 	var buffersSizeElement = document.getElementById("buffer_size");
 	var bufferSize = buffersSizeElement.value;
 	var bufferSizeUnits = document.getElementById("buffer_size_units").value;
-	if (   !buffersSizeElement.disabled
-	    && (bufferSize != 8 || bufferSizeUnits != "k") )
+	if (!buffersSizeElement.disabled
+		&& (bufferSize != 8 || bufferSizeUnits != "k") )
 	{
-	    buffersString += bufferSize + bufferSizeUnits + ",";
+		buffersString += bufferSize + bufferSizeUnits + ",";
 	}
-	
+
 	// Dynamic buffers
 	var dynamicBuffersElement = document.getElementById("dynamic_buffers");
 	if (!dynamicBuffersElement.disabled && !dynamicBuffersElement.checked) {
-	    buffersString += "nodynamic";
+		buffersString += "nodynamic";
 	}
-	
+
 	// Add brackets if necessary
 	buffersString = removeFinalCommaIfPresent(buffersString);
 	if (buffersString.indexOf(",") != -1) {
-        buffersString = "{" + buffersString + "}";
+		buffersString = "{" + buffersString + "}";
 	}
 
 	// Add prefix and trailing comma if the string isn't empty
 	if (buffersString != "") {
-	    buffersString = "buffers=" + buffersString + ",";	
-    }	
-	
+		buffersString = "buffers=" + buffersString + ",";	
+	}	
+
 	var regularOutputString = "";
 	var exceptionOutputString = "";
-	
+
 	// Regular output file
 	// output=<filename>[,sizem[,<generations>]]
 	// This field is optional (can trigger snap traces instead)
 	var fileElement = document.getElementById("file_text");
 	if (!fileElement.disabled) {
-	    var fileString = fileElement.value;
+		var fileString = fileElement.value;
 		if (fileString != "") {
-		    // Escape quotes in the filename
+			// Escape quotes in the filename
 			// (I'm not sure what sort of monster would put quotes in the filename, but hey)
 			fileString = fileString.replace(/"/g, "\\\"");
-			
+
 			// Wrap the filename in quotes if the entire option isn't going to be wrapped in quotes
 			if (document.getElementById("wrap_in_quotes").checked) {
-			    regularOutputString += fileString + ",";
+				regularOutputString += fileString + ",";
 			} else {
-			    regularOutputString += "\"" + fileString + "\",";
+				regularOutputString += "\"" + fileString + "\",";
 			}
-			
+
 			// Max size and generations
 			var maxSize = document.getElementById("output_size").value;
 			var maxGenerations = document.getElementById("output_generations").value;
 			if (maxSize != 0) {
-			    regularOutputString = "{" + regularOutputString + maxSize + "m,";
-			    if (maxGenerations > 1) {
-    			    regularOutputString += maxGenerations;
-			    }
+				regularOutputString = "{" + regularOutputString + maxSize + "m,";
+				if (maxGenerations > 1) {
+					regularOutputString += maxGenerations;
+				}
 				regularOutputString = removeFinalCommaIfPresent(regularOutputString);
-	            regularOutputString += "},";
+				regularOutputString += "},";
 			}
 			regularOutputString = "output=" + regularOutputString;
 		}
 	}
-	
+
 	// Exception output file
 	// exception.output=<filename>[,nnnm]
 	// This field is *mandatory* if the Exception destination is selected
 	fileElement = document.getElementById("file_text_exception");
 	if (!fileElement.disabled) {
-	    var fileString = fileElement.value;
-		
+		var fileString = fileElement.value;
+
 		// Escape quotes in the filename
 		// (I'm not sure what sort of monster would put quotes in the filename, but hey)
 		fileString = fileString.replace(/"/g, "\\\"");
-			
+
 		// Wrap the filename in quotes if the entire option isn't going to be wrapped in quotes
 		if (document.getElementById("wrap_in_quotes").checked) {
-		    exceptionOutputString += fileString + ",";
+			exceptionOutputString += fileString + ",";
 		} else {
-		    exceptionOutputString += "\"" + fileString + "\",";
+			exceptionOutputString += "\"" + fileString + "\",";
 		}
-		
+
 		// Maximum size
 		var maxSize = document.getElementById("output_size_exception").value;
 		if (maxSize != 0) {
-		    exceptionOutputString = "{" + exceptionOutputString + maxSize + "m},";
+			exceptionOutputString = "{" + exceptionOutputString + maxSize + "m},";
 		}
 		exceptionOutputString = "exception.output=" + exceptionOutputString;
 	}
-	
+
 	var outputString = buffersString + regularOutputString + exceptionOutputString;
-	
+
 	return removeFinalCommaIfPresent(outputString);
 }
 
 // Return true if a string contains characters that are reserved on some platforms
 // Otherwise return false
 function containsReservedChars(string) {
-	if (   string.indexOf("\\") != -1
+	if (string.indexOf("\\") != -1
 		|| string.indexOf("/") != -1
 		|| string.indexOf(":") != -1
 		|| string.indexOf("*") != -1
@@ -2139,246 +2138,246 @@ function containsReservedChars(string) {
 		|| string.indexOf(">") != -1
 		|| string.indexOf("|") != -1
 	) {
-	    return true;
+		return true;
 	} else {
-	    return false;
+		return false;
 	}	
 }
 
 function setErrorStyle(inputElement) {
-    // Only set the error style if this element doesn't have focus.
+	// Only set the error style if this element doesn't have focus.
 	if (document.activeElement != inputElement) {
 		inputElement.style.borderColor = "red";
-	    inputElement.style.borderStyle = "solid";
+		inputElement.style.borderStyle = "solid";
 	}
 }
 
 function unsetErrorStyle(inputElement) {
-    inputElement.style.borderColor = "";
+	inputElement.style.borderColor = "";
 	inputElement.style.borderStyle = "";
 }
 
 function escapeHTML(text) {
-    return text.replace(/&/g, "&amp;")
-               .replace(/</g, "&lt;")
-               .replace(/>/g, "&gt;")
-               .replace(/"/g, "&quot;")
-               .replace(/'/g, "&#039;");
+	return text.replace(/&/g, "&amp;")
+	           .replace(/</g, "&lt;")
+	           .replace(/>/g, "&gt;")
+	           .replace(/"/g, "&quot;")
+	           .replace(/'/g, "&#039;");
 }
 
 // Inserts text in a target text input, replacing the current selected text
 // Also gives focus to the target text input
 function insertText(targetElement, textToInsert) {
-    var oldTextValue = targetElement.value;
+	var oldTextValue = targetElement.value;
 	var selectionStart = targetElement.selectionStart;
 	var selectionEnd = targetElement.selectionEnd;
-    
+
 	// Get text before/after current selection
 	var textBeforeSelection = oldTextValue.substring(0, selectionStart);
 	var textAfterSelection = oldTextValue.substring(selectionEnd, oldTextValue.length);
 	
 	// Insert text, effectively replacing the current selection
-    targetElement.value = textBeforeSelection + textToInsert + textAfterSelection;
-    
+	targetElement.value = textBeforeSelection + textToInsert + textAfterSelection;
+
 	// Set cursor position to the end of the inserted text
 	var cursorPosition = selectionStart + textToInsert.length;
-    
+
 	// Make sure nothing is selected
 	targetElement.selectionStart = cursorPosition;
-    targetElement.selectionEnd = cursorPosition;
-    
+	targetElement.selectionEnd = cursorPosition;
+
 	// Give focus to the target field
 	targetElement.focus();
 }
 
 function copyTextToClipboard(element) {
-    var selection = window.getSelection(); // get the window's Selection object
-    selection.removeAllRanges(); // deselect any user selected text
-	
+	var selection = window.getSelection(); // get the window's Selection object
+	selection.removeAllRanges(); // deselect any user selected text
+
 	// Create a temporary element and store the target element's text in it
 	// (while stripping out any HTML tags)
 	var tempElement = document.createElement("p");
-	tempElement.innerHTML = element.innerText;
-	
+	tempElement.innerText = element.innerText;
+
 	// Append temporary element to the DOM so we can copy its contents
-    document.body.appendChild(tempElement);
-	
+	document.body.appendChild(tempElement);
+
 	var range = document.createRange(); // create a new range object
-    range.selectNodeContents(tempElement); // set range to cover target element text
-    selection.addRange(range); // add range to Selection object
-	
+	range.selectNodeContents(tempElement); // set range to cover target element text
+	selection.addRange(range); // add range to Selection object
+
 	document.execCommand("copy"); // do the copy
 	selection.removeAllRanges(); // deselect the target element's text
-	
+
 	// Remove the temporary text area
 	tempElement.parentNode.removeChild(tempElement);
 }
 
 function copyLinkToClipboard() {
 	var serializedForm = "";
-		
+
 	// Serialize the tracepoints
 	var tracepointListElements = document.getElementById("tracepoint_input").getElementsByTagName("li");
 	for (var i = 0; i < tracepointListElements.length; i++) {
-	    var type = tracepointListElements[i].getAttribute("data-type");
+		var type = tracepointListElements[i].getAttribute("data-type");
 		var serializedTracepoint = "";
 		var tracepointFormElements = tracepointListElements[i].getElementsByTagName("*");
 		for (var j = 0; j < tracepointFormElements.length; j++) {
-		    // Get the element ID and modify the index
+			// Get the element ID and modify the index
 			var elementId = tracepointFormElements[j].id.replace(/\d+/g, i);
-						
+
 			switch (tracepointFormElements[j].tagName) {
-			    case "SELECT":
-				    // id = selected value
-				    var selectedValue = getSelectedElement(tracepointFormElements[j]).value;
-				    serializedTracepoint += elementId + "=" + selectedValue + "&";
+				case "SELECT":
+					// id = selected value
+					var selectedValue = getSelectedElement(tracepointFormElements[j]).value;
+					serializedTracepoint += elementId + "=" + selectedValue + "&";
 					break;
-			
-			    case "INPUT":
-				    if (tracepointFormElements[j].type == "text" && tracepointFormElements[j].value != "") {
-			            // id = URI encoded value
-    				    serializedTracepoint += elementId + "=";
-				        serializedTracepoint += encodeURIComponent(tracepointFormElements[j].value);
-				        serializedTracepoint += "&";
-			        }
+
+				case "INPUT":
+					if (tracepointFormElements[j].type == "text" && tracepointFormElements[j].value != "") {
+						// id = URI encoded value
+						serializedTracepoint += elementId + "=";
+						serializedTracepoint += encodeURIComponent(tracepointFormElements[j].value);
+						serializedTracepoint += "&";
+					}
 					if (tracepointFormElements[j].type == "radio" && tracepointFormElements[j].checked) {
-			            // id = 1 (checked) (unchecked radio options are not needed)
-			            serializedTracepoint += elementId + "=1&";
-			        }
+						// id = 1 (checked) (unchecked radio options are not needed)
+						serializedTracepoint += elementId + "=1&";
+					}
 					break;
 			}
 		}
-	    // URI encode the whole lot and use the result as the value for the tracepoint parameter
+		// URI encode the whole lot and use the result as the value for the tracepoint parameter
 		serializedForm += "tracepoint_" + type + "_" + i + "=";
 		serializedForm += encodeURIComponent(removeFinalAmpersandIfPresent(serializedTracepoint));
 		serializedForm += "&";
 	}
-	
+
 	// Serialize the methods
 	var methodListElements = document.getElementById("method_input").getElementsByTagName("li");
 	for (var i = 0; i < methodListElements.length; i++) {
-	    var regexArray = methodListElements[i].id.match(/method_(\d+)/)
+		var regexArray = methodListElements[i].id.match(/method_(\d+)/)
 		var methodIndex = regexArray[1];
-		
+
 		// Method text/spec	
 		var methodText = document.getElementById("meth_text_" + methodIndex).value;
-		
+
 		// Args checkbox
 		var methodArgs = 0;
 		if (document.getElementById("meth_args_" + methodIndex).checked) {
-		    methodArgs = 1;
+			methodArgs = 1;
 		}
-		
+
 		var serializedMethod = "meth_text_" + i + "=" + encodeURIComponent(methodText) + "&" +
 		                       "meth_args_" + i + "=" + methodArgs;
 		
 		// URI encode the whole lot and use the result as the value for the method parameter
 		serializedForm += "method_" + i + "=" + encodeURIComponent(serializedMethod) + "&";
-    }
+	}
 	
 	// Serialize the triggers
 	var triggerListElements = document.getElementById("trigger_input").getElementsByTagName("li");
 	for (var i = 0; i < triggerListElements.length; i++) {
-	    var type = triggerListElements[i].getAttribute("data-type");
+		var type = triggerListElements[i].getAttribute("data-type");
 		var serializedTrigger = "";
 		var triggerFormElements = triggerListElements[i].getElementsByTagName("*");
 		for (var j = 0; j < triggerFormElements.length; j++) {
-		    // Get the element ID and modify the index
+			// Get the element ID and modify the index
 			var elementId = triggerFormElements[j].id.replace(/\d+/g, i);
-						
+
 			switch (triggerFormElements[j].tagName) {
-			    case "SELECT":
-				    // id = selected value
-				    var selectedValue = getSelectedElement(triggerFormElements[j]).value;
-				    serializedTrigger += elementId + "=" + selectedValue + "&";
-			        break;
-			
-			    case "INPUT":
-				    if (triggerFormElements[j].type == "text" && triggerFormElements[j].value != "") {
-					    // id = URI encoded value
-				        serializedTrigger += elementId + "=";
-				        serializedTrigger += encodeURIComponent(triggerFormElements[j].value);
-				        serializedTrigger += "&";
-				    }
-					
+				case "SELECT":
+					// id = selected value
+					var selectedValue = getSelectedElement(triggerFormElements[j]).value;
+					serializedTrigger += elementId + "=" + selectedValue + "&";
+					break;
+
+				case "INPUT":
+					if (triggerFormElements[j].type == "text" && triggerFormElements[j].value != "") {
+						// id = URI encoded value
+						serializedTrigger += elementId + "=";
+						serializedTrigger += encodeURIComponent(triggerFormElements[j].value);
+						serializedTrigger += "&";
+					}
+
 					if (triggerFormElements[j].type == "number" && triggerFormElements[j].value != 0) {
-			            // id = value
-				        serializedTrigger += elementId + "=" + triggerFormElements[j].value + "&";
-			        }
+						// id = value
+						serializedTrigger += elementId + "=" + triggerFormElements[j].value + "&";
+					}
 					break;
 			}			
 		}
-	    // URI encode the whole lot and use the result as the value for the tracepoint parameter
+		// URI encode the whole lot and use the result as the value for the tracepoint parameter
 		serializedForm += "trigger_" + type + "_" + i + "=";
 		serializedForm += encodeURIComponent(removeFinalAmpersandIfPresent(serializedTrigger));
 		serializedForm += "&";
 	}
-	
+
 	// Serialize select elements outside tracepoints/methods/triggers
 	var selectElements = document.getElementById("XtraceForm").getElementsByTagName("select");
 	for (var i = 0; i < selectElements.length; i++) {
-	    // Ignore any elements which are part of tracepoints/methods/triggers
-	    if (   selectElements[i].id.indexOf("tp_") == -1
+		// Ignore any elements which are part of tracepoints/methods/triggers
+		if (selectElements[i].id.indexOf("tp_") == -1
 			&& selectElements[i].id.indexOf("meth_") == -1
 			&& selectElements[i].id.indexOf("trig_") == -1)
-	    {
-	        // id = value
+		{
+			// id = value
 			var selectedValue = getSelectedElement(selectElements[i]).value;
 			serializedForm += selectElements[i].id + "=" + selectedValue + "&";
 		}
 	}
-	
+
 	// Serialize input elements outside tracepoints/methods/triggers
 	var inputElements = document.getElementById("XtraceForm").getElementsByTagName("input");
 	for (var i = 0; i < inputElements.length; i++) {
-	    // Ignore any elements which are part of tracepoints/methods/triggers
-	    if (   inputElements[i].id.indexOf("tp_") == -1
+		// Ignore any elements which are part of tracepoints/methods/triggers
+		if (inputElements[i].id.indexOf("tp_") == -1
 			&& inputElements[i].id.indexOf("meth_") == -1
 			&& inputElements[i].id.indexOf("trig_") == -1)
 		{
-	        if (inputElements[i].type == "text" && inputElements[i].value != "") {
+			if (inputElements[i].type == "text" && inputElements[i].value != "") {
 				// id = URI encoded value
-			    serializedForm += inputElements[i].id + "=";
-			    serializedForm += encodeURIComponent(inputElements[i].value);
-			    serializedForm += "&";
+				serializedForm += inputElements[i].id + "=";
+				serializedForm += encodeURIComponent(inputElements[i].value);
+				serializedForm += "&";
 			}
-					
+
 			if (inputElements[i].type == "number" && inputElements[i].value != 0) {
-			    // id = value
-			    serializedForm += inputElements[i].id + "=" + inputElements[i].value + "&";
+				// id = value
+				serializedForm += inputElements[i].id + "=" + inputElements[i].value + "&";
 			}
-					
+
 			if (inputElements[i].type == "checkbox") {
-			    // id = 0|1 (unchecked|checked)
-			    serializedForm += inputElements[i].id + "=";
-			    if (inputElements[i].checked) {
-				    serializedForm += "1&";
+				// id = 0|1 (unchecked|checked)
+				serializedForm += inputElements[i].id + "=";
+				if (inputElements[i].checked) {
+					serializedForm += "1&";
 				} else {
-				    serializedForm += "0&";						
+					serializedForm += "0&";						
 				}
 			}
 		}
 	}
-	
+
 	// Remove final ampersand
 	serializedForm = removeFinalAmpersandIfPresent(serializedForm);
-		
+
 	// Get the base URL
 	var urlString = window.location.protocol + '//' + window.location.host + window.location.pathname;
-		
+
 	// Append the serialized form data
 	urlString += "?" + serializedForm;
-	
+
 	// Create a temporary element and store the URL in it
 	var tempElement = document.createElement("p");
 	tempElement.innerHTML = urlString;
-	
+
 	// Append temporary element to the DOM so we can copy its contents
-    document.body.appendChild(tempElement);
-	
+	document.body.appendChild(tempElement);
+
 	// Copy to the clipboard
 	copyTextToClipboard(tempElement);
-	
+
 	// Remove the temporary text area
 	tempElement.parentNode.removeChild(tempElement);
 }
@@ -2387,14 +2386,14 @@ function copyLinkToClipboard() {
 function clearAndReload() {
 	if (confirm("Are you sure you want to set all options to default values?")) {
 		location.replace(window.location.pathname);	
-    } else {
-        // Do nothing
-    }
+	} else {
+		// Do nothing
+	}
 }
 
 // This is the alternative action to submitting the form when the user presses return in a text field
 function handleSubmit() {
-    processChange("none");
+	processChange("none");
 	return false;
 }
 
@@ -2402,63 +2401,63 @@ function handleSubmit() {
 
 <style> 
 body {
-    font-family: verdana;
-    font-size: 10pt;
+	font-family: verdana;
+	font-size: 10pt;
 }
 
 table {
-    font-size: 10pt;
+	font-size: 10pt;
 }
 
 button {
-    font-size: 10pt;
+	font-size: 10pt;
 	padding: 2px;
 }
 
 button.add {
-    width: 110px;
+	width: 110px;
 }
 
 label {
-    vertical-align: middle;
+	vertical-align: middle;
 }
 
 input {
-    vertical-align: middle;
+	vertical-align: middle;
 }
 
 input[type=text] {
-    padding: 2px 2px;
+	padding: 2px 2px;
 	box-sizing: border-box;
 }
 
 input[type=number] {
-    padding: 2px 2px;
-    box-sizing: border-box;
+	padding: 2px 2px;
+	box-sizing: border-box;
 	width: 70px;
 }
 
 select {
-    padding: 2px 2px;
-    box-sizing: border-box;
+	padding: 2px 2px;
+	box-sizing: border-box;
 	vertical-align: middle;
 }
 
 label[data-disabled=true] {
-    color: #ccc;
+	color: #ccc;
 }
 
 label[data-disabled=false] {
-    color: #000;
+	color: #000;
 }
 
 td {
-    vertical-align: middle;
+	vertical-align: middle;
 	height: 20px">
 }
 
 ul {
-    list-style-type: none;
+	list-style-type: none;
 	min-height: 85px;
 	padding-left: 5px;
 	padding-top: 0px;
@@ -2466,13 +2465,13 @@ ul {
 }
 
 li {
-    padding: 2px 0px;	
+	padding: 2px 0px;	
 }
 
 a.remove {
-    vertical-align: middle;
+	vertical-align: middle;
 	font-size: 12pt;
-    text-decoration: none;
+	text-decoration: none;
 	color: red;
 }
 
@@ -2498,30 +2497,30 @@ The project website pages cannot be redistributed
 <table border="0" cellspacing="0" cellpadding="4" style="width:100%; table-layout:fixed">
 <tbody>
 <tr>
-    <td  class="head1" colspan="2">
-        OpenJ9: Xtrace Option Builder
-    </td>
+	<td  class="head1" colspan="2">
+	        OpenJ9: Xtrace Option Builder
+	</td>
 </tr>
-      </tbody></table>
-        <br/><br/>
-
+</tbody>
+</table>
+<br/><br/>
 
 
 <table cellpadding="1">
-    <tr>
-	    <td width="120">
-		    <b style="font-size: 12pt">Tracepoints</b>
+	<tr>
+		<td width="120">
+			<b style="font-size: 12pt">Tracepoints</b>
 		</td>
 		<td>
-            <button type="button" class="add" id="button_add_tracepoint_id" title="Enable specific tracepoint(s) by ID" onclick="addTracepoint('id', null)">ID</button>
-        </td>
-        <td>
+			<button type="button" class="add" id="button_add_tracepoint_id" title="Enable specific tracepoint(s) by ID" onclick="addTracepoint('id', null)">ID</button>
+		</td>
+		<td>
 			<button type="button" class="add" id="button_add_tracepoint_component" title="Enable tracepoints for a component" onclick="addTracepoint('component', null)">Component</button>
-        </td>
-        <td>
+		</td>
+		<td>
 			&nbsp;
 			<input disabled type="checkbox" id="disable_predefined" name="disable_predefined" value="disable_predefined" title="Disables all tracepoints that are enabled by default" checked onchange="processChange(this)">
-            <label data-disabled="true" for="disable_predefined" title="Disables all tracepoints that are enabled by default (destination: maximal buffers)">Disable default tracepoints</label>
+			<label data-disabled="true" for="disable_predefined" title="Disables all tracepoints that are enabled by default (destination: maximal buffers)">Disable default tracepoints</label>
 		</td>		    
 	</tr>
 </table>
@@ -2529,7 +2528,7 @@ The project website pages cannot be redistributed
 <hr>
 		
 <ul id="tracepoint_input">
-<!-- Tracepoint forms will be added here -->
+	<!-- Tracepoint forms will be added here -->
 </ul>
 		
 <br>
@@ -2538,27 +2537,27 @@ The project website pages cannot be redistributed
 
 <table cellpadding="1">
 	<tr>
-	    <td width="120">
+		<td width="120">
 			<b style="font-size: 12pt">Methods</b>
-        </td>
-		<td>
-		    <button type="button" class="add" id="button_add_method" title="Specify a method to trace" onclick="addMethod()">Method</button>
 		</td>
-    </tr>
+		<td>
+			<button type="button" class="add" id="button_add_method" title="Specify a method to trace" onclick="addMethod()">Method</button>
+		</td>
+	</tr>
 </table>
 		
 <hr>
 		
 <ul id="method_input">
-    <!-- Method forms will be added here -->
+	<!-- Method forms will be added here -->
 </ul>
 <br>
 
 <table cellpadding="1">
-    <tr>
-	    <td width="120">
-		    <!-- https://www.ibm.com/support/knowledgecenter/en/SSYKE2_8.0.0/com.ibm.java.lnx.80.doc/diag/tools/trace_options_trigger.html -->
-            <b style="font-size: 12pt">Triggers</b>
+	<tr>
+		<td width="120">
+			<!-- https://www.ibm.com/support/knowledgecenter/en/SSYKE2_8.0.0/com.ibm.java.lnx.80.doc/diag/tools/trace_options_trigger.html -->
+			<b style="font-size: 12pt">Triggers</b>
 		</td>
 		<td>
 			<button type="button" class="add" id="button_add_trigger_method" title="Add method trigger" onclick="addTrigger('method')">Method</button>
@@ -2566,21 +2565,21 @@ The project website pages cannot be redistributed
 		<td>
 			<button type="button" class="add" id="button_add_trigger_tracepoint" title="Add tracepoint trigger" onclick="addTrigger('tracepoint')">Tracepoint</button>
 		</td>
-        <td>
-		    <button type="button" class="add" id="button_add_trigger_group" title="Add group trigger" onclick="addTrigger('group')">Group</button>
+		<td>
+			<button type="button" class="add" id="button_add_trigger_group" title="Add group trigger" onclick="addTrigger('group')">Group</button>
 		</td>
 		<td id="trace_initially_disabled_td">
 			&nbsp;
 			<input type="checkbox" id="trace_initially_disabled" name="trace_initially_disabled" value="trace_initially_disabled" title="Trace can be started with a trigger, e.g. when entering a specific method" onchange="processChange(this)">
 			<label for="trace_initially_disabled" title="Trace can be started with a trigger, e.g. when entering a specific method">Trace initially stopped</label>	
-        </td>
+		</td>
 		<td title="Length of time to sleep for the &quot;thread sleep&quot; action">
 			&nbsp;
 			<label data-disabled="true" for="sleep_time">Sleep time (ms): </label>	
 			<input disabled type="number" id="sleep_time" min="1" value="30000" size="1" onchange="processChange(this)" onblur="processChange(this)">
-        </td>
+		</td>
 		<td title="Maximum number of stack frames to include for the &quot;jstacktrace&quot; action (0 = no limit)">
-		    &nbsp;
+			&nbsp;
 			<label data-disabled="true" for="stack_depth">Stack depth: </label>	
 			<input disabled type="number" id="stack_depth" value="0" min="1" onchange="processChange(this)" onblur="processChange(this)">
 		</td>		
@@ -2590,30 +2589,30 @@ The project website pages cannot be redistributed
 <hr>
 		
 <ul id="trigger_input">
-    <!-- Trigger forms will be added here -->
+	<!-- Trigger forms will be added here -->
 </ul>
 <br>
 
 <table cellpadding="1">
 	<tr>
-	    <td width="200">
+		<td width="200">
 			<b style="font-size: 12pt">Trace Buffer Output</b>
-        </td>
+		</td>
 		<td title="Size of trace buffers - per thread for regular buffers, global for exception buffers">
-		    <label for="buffer_size">Buffer size: </label>	
+			<label for="buffer_size">Buffer size: </label>	
 			<input type="number" id="buffer_size" value="8" min="1" max="9999" onchange="processChange(this)">
-		    <select id="buffer_size_units" name="buffer_size_units" title="Buffer size units" size="1" onchange="processChange(this)">
-                <option value="k" selected> kilobytes</option>
-                <option value="m"> megabytes </option>
-            </select>    
+			<select id="buffer_size_units" name="buffer_size_units" title="Buffer size units" size="1" onchange="processChange(this)">
+			<option value="k" selected> kilobytes</option>
+			<option value="m"> megabytes </option>
+			</select>    
 		</td>
 		<td title="Dynamically allocate buffers to match IO rate for output file">
-		    &nbsp;
+			&nbsp;
 			<input disabled type="checkbox" id="dynamic_buffers" name="dynamic_buffers" checked onchange="processChange(this)">
 			<label data-disabled="true" for="dynamic_buffers">Use dynamic buffers</label>	
 		</td>
 		<td>
-		    &nbsp;
+			&nbsp;
 			<a href="http://www.eclipse.org/openj9/docs/tool_traceformat/">How to format binary trace output</a>		
 		</td>
 	</tr>
@@ -2621,70 +2620,70 @@ The project website pages cannot be redistributed
 <hr>
 
 <table>
-    <tr>
-        <td style="min-width: 190px">
-            <label data-disabled="true" for="file_text">Regular output file name:</label>
-        </td>
-        <td>
-            <input disabled type="text" id="file_text" name="file_text" size="30" value="" onchange="processChange(this)" onblur="processChange(this)">
-        </td>
-        <td>
-            <input disabled type="button" data-target="file_text" data-token="%p" id="file_button_pid"  style="font-size: 8pt; height:23px;width:45px" onclick="processChange(this)"
-                value="PID" title="Process ID e.g. 27491">
-            <input disabled type="button" data-target="file_text" data-token="%d" id="file_button_date" style="font-size: 8pt; height:23px;width:45px" onclick="processChange(this)"
-                value="Date" title="Date (yyyymmdd)">
-            <input disabled type="button" data-target="file_text" data-token="%t" id="file_button_time" style="font-size: 8pt; height:23px;width:45px" onclick="processChange(this)"
-                value="Time" title="Time (24-hour hhmmss)">
-            <input disabled type="button" data-target="file_text" data-token="#" id="file_button_counter" style="font-size: 8pt; height:23px;width:75px" onclick="processChange(this)"
-                value="File counter" title="Incremental file counter. Use with &quot;Maximum number of files&quot; below".>
-        </td>
-    </tr>
-   	<tr>
-        <td>
-  		    <label data-disabled="true" for="output_size">Maximum file size (MB):</label>
-   		</td>
-        <td>
-            <input disabled type="number" id="output_size" name="output_size" min="0" max="9999" value="0" size="4" onchange="processChange(this)" onblur="processChange(this)" title="When the file reaches this size it will wrap to the beginning. If set to 0, the file size is limited only by disk space.">
-            <label data-disabled="true" for="output_size">(0 = no limit)</label>
-    	</td>
-    </tr>
 	<tr>
-        <td>
-		    <label data-disabled="true" for="output_generations">Maximum number of files:</label>
+		<td style="min-width: 190px">
+			<label data-disabled="true" for="file_text">Regular output file name:</label>
 		</td>
-	    <td>
-            <input disabled type="number" id="output_generations" name="output_generations" min="1" max="36" value="1" size="4" onchange="processChange(this)" onblur="processChange(this)">
-            <label data-disabled="true" for="output_generations"></label>
-	    </td>
+		<td>
+			<input disabled type="text" id="file_text" name="file_text" size="30" value="" onchange="processChange(this)" onblur="processChange(this)">
+		</td>
+		<td>
+			<input disabled type="button" data-target="file_text" data-token="%p" id="file_button_pid"  style="font-size: 8pt; height:23px;width:45px" onclick="processChange(this)"
+				value="PID" title="Process ID e.g. 27491">
+			<input disabled type="button" data-target="file_text" data-token="%d" id="file_button_date" style="font-size: 8pt; height:23px;width:45px" onclick="processChange(this)"
+				value="Date" title="Date (yyyymmdd)">
+			<input disabled type="button" data-target="file_text" data-token="%t" id="file_button_time" style="font-size: 8pt; height:23px;width:45px" onclick="processChange(this)"
+				value="Time" title="Time (24-hour hhmmss)">
+			<input disabled type="button" data-target="file_text" data-token="#" id="file_button_counter" style="font-size: 8pt; height:23px;width:75px" onclick="processChange(this)"
+				value="File counter" title="Incremental file counter. Use with &quot;Maximum number of files&quot; below".>
+		</td>
+	</tr>
+   	<tr>
+		<td>
+  			<label data-disabled="true" for="output_size">Maximum file size (MB):</label>
+   		</td>
+		<td>
+			<input disabled type="number" id="output_size" name="output_size" min="0" max="9999" value="0" size="4" onchange="processChange(this)" onblur="processChange(this)" title="When the file reaches this size it will wrap to the beginning. If set to 0, the file size is limited only by disk space.">
+			<label data-disabled="true" for="output_size">(0 = no limit)</label>
+		</td>
+	</tr>
+	<tr>
+        	<td>
+			<label data-disabled="true" for="output_generations">Maximum number of files:</label>
+		</td>
+		<td>
+			<input disabled type="number" id="output_generations" name="output_generations" min="1" max="36" value="1" size="4" onchange="processChange(this)" onblur="processChange(this)">
+			<label data-disabled="true" for="output_generations"></label>
+		</td>
 	</tr>
 </table>
 <br>
 <table>
-    <tr>
-        <td style="min-width: 190px">
-            <label data-disabled="true" for="file_text_exception">Exception output file name:</label>
-        </td>
-        <td>
-            <input disabled type="text" id="file_text_exception" name="file_text_exception" size="30" value="" onchange="processChange(this)" onblur="processChange(this)">
-        </td>
-        <td>
-            <input disabled type="button" data-target="file_text_exception" data-token="%p" id="file_button_pid_exception"  style="font-size: 8pt; height:23px;width:45px" onclick="processChange(this)"
-                value="PID" title="Process ID e.g. 27491">
-            <input disabled type="button" data-target="file_text_exception" data-token="%d" id="file_button_date_exception" style="font-size: 8pt; height:23px;width:45px" onclick="processChange(this)"
-                value="Date" title="Date (yyyymmdd)">
-            <input disabled type="button" data-target="file_text_exception" data-token="%t" id="file_button_time_exception" style="font-size: 8pt; height:23px;width:45px" onclick="processChange(this)"
-                value="Time" title="Time (24-hour hhmmss)">
-        </td>
-    </tr>
-    <tr>
-        <td>
-    	    <label data-disabled="true" for="output_size_exception">Maximum file size (MB):</label>
-    	</td>
-        <td>
-            <input disabled type="number" id="output_size_exception" name="output_size_exception" min="0" max="9999" value="0" size="4" onchange="processChange(this)" onblur="processChange(this)" title="When the file reaches this size it will wrap to the beginning. If set to 0, the file size is limited only by disk space.">
-            <label data-disabled="true" for="output_size_exception">(0 = no limit)</label>
-    	</td>
-    </tr>
+	<tr>
+		<td style="min-width: 190px">
+			<label data-disabled="true" for="file_text_exception">Exception output file name:</label>
+		</td>
+		<td>
+			<input disabled type="text" id="file_text_exception" name="file_text_exception" size="30" value="" onchange="processChange(this)" onblur="processChange(this)">
+		</td>
+		<td>
+			<input disabled type="button" data-target="file_text_exception" data-token="%p" id="file_button_pid_exception"  style="font-size: 8pt; height:23px;width:45px" onclick="processChange(this)"
+				value="PID" title="Process ID e.g. 27491">
+			<input disabled type="button" data-target="file_text_exception" data-token="%d" id="file_button_date_exception" style="font-size: 8pt; height:23px;width:45px" onclick="processChange(this)"
+				value="Date" title="Date (yyyymmdd)">
+			<input disabled type="button" data-target="file_text_exception" data-token="%t" id="file_button_time_exception" style="font-size: 8pt; height:23px;width:45px" onclick="processChange(this)"
+				value="Time" title="Time (24-hour hhmmss)">
+		</td>
+	</tr>
+	<tr>
+		<td>
+			<label data-disabled="true" for="output_size_exception">Maximum file size (MB):</label>
+		</td>
+		<td>
+			<input disabled type="number" id="output_size_exception" name="output_size_exception" min="0" max="9999" value="0" size="4" onchange="processChange(this)" onblur="processChange(this)" title="When the file reaches this size it will wrap to the beginning. If set to 0, the file size is limited only by disk space.">
+			<label data-disabled="true" for="output_size_exception">(0 = no limit)</label>
+		</td>
+	</tr>
 </table>
 
 
@@ -2693,14 +2692,13 @@ The project website pages cannot be redistributed
 <hr>
 <p>
 	<input type="checkbox" id="wrap_in_quotes" name="wrap_in_quotes" value="wrap_in_quotes" onchange="processChange(this)">
-    <label for="wrap_in_quotes">Wrap in quotes (for use in a shell)</label>
+	<label for="wrap_in_quotes">Wrap in quotes (for use in a shell)</label>
 </p>
 <p>
 	<button type="button" id="button_copy_to_clipboard" style="font-size: 12pt; height:30px;width:200px" onclick="copyTextToClipboard(document.getElementById('result'))" title="Copy this -Xtrace option to the clipboard">Copy option</button>
-    <button type="button" id="button_copy_link_to_clipboard" style="font-size: 12pt; height:30px;width:200px" onclick="copyLinkToClipboard()" title="Copy a link to this -Xtrace option to the clipboard">Copy link</button>
-    <button type="button" id="button_reset" style="font-size: 12pt; height:30px;width:200px" onclick="location.reload()" title="Reset all options to the values that were set when this page was originally loaded">Reset</button>
+	<button type="button" id="button_copy_link_to_clipboard" style="font-size: 12pt; height:30px;width:200px" onclick="copyLinkToClipboard()" title="Copy a link to this -Xtrace option to the clipboard">Copy link</button>
+	<button type="button" id="button_reset" style="font-size: 12pt; height:30px;width:200px" onclick="location.reload()" title="Reset all options to the values that were set when this page was originally loaded">Reset</button>
 	<button type="button" id="button_clear" style="font-size: 12pt; height:30px;width:200px" onclick="clearAndReload()" title="Clear all options and set default values">Clear</button>
-	&nbsp;
 </p>
 
 <p id="errors" style="font-size: 12pt; font-family:courier; color:red;">&nbsp;</p></b>


### PR DESCRIPTION
**Xdump Option Builder**

- When using the tool agent, the range is set to 1..1 by default. Otherwise the default is 0..1. This is now reflected in the tool. I also decided to rework the range option slightly so that it is always enabled, but only appears in the result if it is modified from the default.
- Implemented "opts" option for tool agent (ASYNC and WAIT)

**Xtrace Option Builder**

- Fixed a problem with the stack depth option not enabling/disabling correctly, which was caused by missing brackets on a call to isMethodJStackTraceActionSelected()

**Both Option Builders**

- Fixed the indentation, which was a messy mixture of tabs and spaces.

- "Copy option" button was not working properly when the result contained reserved HTML characters - e.g. '<' and '>'. This was caused by mistakenly setting element.innerHTML instead of element.innerText on the temporary element used to store the text to be copied to the clipboard.

Signed-off-by: Paul Cheeseman paul.cheeseman@uk.ibm.com