### PR TITLE
Indicate where to download freemarker in the build instructions

### DIFF
--- a/oj9_build.html
+++ b/oj9_build.html
@@ -158,6 +158,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <pre><code>bash ./configure --with-freemarker-jar=/root/freemarker.jar</code></pre>
           <p>Note that you must give an absolute path to <code>freemarker.jar</code>
           </p>
+          <p>Note the version of freemarker used by OpenJ9 is available from:
+          <pre><code>wget https://sourceforge.net/projects/freemarker/files/freemarker/2.3.8/freemarker-2.3.8.tar.gz/download -O freemarker.tgz</code></pre>
+          </p>
         </div>
       </div>
 
@@ -345,6 +348,9 @@ OpenJDK  - 27f5b8f based on jdk8u152-b03)
           </p>
           <pre><code>bash ./configure --with-freemarker-jar=/root/freemarker.jar</code></pre>
           <p>Note that you must give an absolute path to <code>freemarker.jar</code>
+          </p>
+          <p>Note the version of freemarker used by OpenJ9 is available from:
+          <pre><code>wget https://sourceforge.net/projects/freemarker/files/freemarker/2.3.8/freemarker-2.3.8.tar.gz/download -O freemarker.tgz</code></pre>
           </p>
         </div>
       </div>


### PR DESCRIPTION
A user raised the question of where to get freemarker on slack today.  We should make the build instructions a little more obvious in that regards.  

Currently, the info is only in the docker file.

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>