### PR TITLE
Update pipeline script for untracked files

### DIFF
--- a/jenkinsPullRequests
+++ b/jenkinsPullRequests
@@ -64,7 +64,8 @@ timeout(time: 3, unit: 'HOURS') {
                         sh "cp -r ${WORKSPACE}/${GITHUB_DIR}/* ."
                         sh "cp -r ${WORKSPACE}/${GITHUB_DIR}/.gitignore ."
                         sh 'git status'
-                        sh 'git commit -am "Generated from commit: ${sha1}"'
+                        sh 'git add .'						
+                        sh 'git commit -m "Generated from commit: ${sha1}"'
                         sh "git push origin ${BRANCH}"
                         sh "git diff origin/${BRANCH}..origin/master"
                     }


### PR DESCRIPTION
New files have been added to the website since the
job was created, but we need to 'git add .' to include
them when copied to the staging branch because the line
to 'git commit -am ....' does not take account of new files.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>