### PR TITLE
Option builders - improve quoting behaviour and detect commas

### DIFF
--- a/tools/xdump_option_builder.html
+++ b/tools/xdump_option_builder.html
@@ -788,26 +788,28 @@ function buildAndUpdateResult() {
 		unsetErrorStyle(toolWaitElement);
 	}
 
-	// Check validity of the throwable class string
+	// Check validity of the throwable class filter. Rules:
+	//    1. Can start with a wildcard character
+	//    2. Can end with a wildcard character if no method filter is specified
+	//    3. Can contain just a single wildcard character on its own
+	//    4. Cannot contain a wildcard in any other location
+	//    5. Cannot contain a comma
 	var throwableClassHasError = false;
 	var throwableClassElement = document.getElementById("event_throwable_class")
 	if (!throwableClassElement.disabled) {
 		var classValue = throwableClassElement.value;
+		
 		if (classValue.lastIndexOf("*") > 0) {
-			// Note: a filter containing a single wildcard at the beginning of the string,
-			// or a filter containing just a wildcard (i.e. "*") are fine
-			if (classValue.lastIndexOf("*") != (classValue.length - 1)) {
-				// Wildcard must be placed at the beginning and/or end of the string
+			if (classValue.indexOf("*", 1) != (classValue.length - 1)) {
 				throwableClassHasError = true;
 				errorsHtml += "ERROR: Invalid Exception class filter: wildcards can only be used at the beginning and/or end of the filter<br>";
 			} else if (document.getElementById("event_throwable_method").value != "") {
-				// Wildcard not allowed at the end of the string if a method filter is enabled
 				throwableClassHasError = true
 				errorsHtml += "ERROR: Invalid Exception class filter: must not end with a wildcard when a method filter is specified<br>";
 			}
 		}
 		
-		if (throwableClassElement.value.indexOf(",") != -1) {
+		if (classValue.indexOf(",") != -1) {
 			throwableClassHasError = true;
 			errorsHtml += "ERROR: Invalid Exception class filter: must not contain a comma.<br>";
 		} 
@@ -820,28 +822,31 @@ function buildAndUpdateResult() {
 		}
 	}
 
-	// Check validity of the throwable method string	
+	// Check validity of the throwable method filter. Rules:
+	//    1. Can end with a wildcard character if no stack offset is specified
+	//    2. Cannot contain a wildcard in any other location
+	//    3. Cannot contain a comma	
 	var throwableMethodHasError = false;
 	var throwableMethodElement = document.getElementById("event_throwable_method");
 	if (!throwableMethodElement.disabled) {
 		var methodValue = throwableMethodElement.value;
-		if (methodValue.indexOf("*") != -1) {
-			if (document.getElementById("event_throwable_offset").value != "0") {
-				// No wildcard allowed if using stack offset
-				throwableMethodHasError = true;
-				errorsHtml += "ERROR: Invalid Exception method filter: must not contain a wildcard when using a stack offset.<br>";
-			} else if (methodValue.indexOf("*") != (methodValue.length - 1)) {
-				// If no stack offset, wildcard must be placed at the end
+
+		var wildcardIndex = methodValue.indexOf("*");
+		if (wildcardIndex != -1) {
+			if (wildcardIndex != (methodValue.length - 1)) {
 				throwableMethodHasError = true;
 				errorsHtml += "ERROR: Invalid Exception method filter: wildcard can only be used at the end of the filter<br>";
-			}
+			} else if (document.getElementById("event_throwable_offset").value != "0") {
+				throwableMethodHasError = true;
+				errorsHtml += "ERROR: Invalid Exception method filter: must not end with a wildcard when using a non-zero stack offset.<br>";
+			}		
 		}
-		
-		if (throwableMethodElement.value.indexOf(",") != -1) {
+
+		if (methodValue.indexOf(",") != -1) {
 			throwableMethodHasError = true;
 			errorsHtml += "ERROR: Invalid Exception method filter: must not contain a comma.<br>";
 		} 
-		
+
 		if (throwableMethodHasError) {
 			resultIsGreen = false;
 			setErrorStyle(throwableMethodElement);

--- a/tools/xdump_option_builder.html
+++ b/tools/xdump_option_builder.html
@@ -616,17 +616,9 @@ function buildAndUpdateResult() {
 	}
 
 	// msg_filter
-	var messageFilterString = document.getElementById("event_throwable_msg_filter").value;
-	if (document.getElementById("event_throwable_msg_filter").disabled == false && messageFilterString != "") {
-		// Escape quotes in the filter
-		messageFilterString = messageFilterString.replace(/"/g, "\\\"");
-
-		// Wrap the command in quotes if the entire option isn't going to be wrapped in quotes
-		if (document.getElementById("wrap_in_quotes").checked) {
-			resultString += ",msg_filter=" + messageFilterString;
-		} else {
-			resultString += ",msg_filter=\"" + messageFilterString + "\"";
-		}
+	var messageFilterStringElement = document.getElementById("event_throwable_msg_filter");
+	if (messageFilterStringElement.disabled == false && messageFilterStringElement.value != "") {
+		resultString += ",msg_filter=" + messageFilterStringElement.value;
 	}
 
 	// range
@@ -656,15 +648,7 @@ function buildAndUpdateResult() {
 	if (document.getElementById("agent_tool").checked) {
         var execString = document.getElementById("exec").value;
 		if (execString != "") {
-			// Escape quotes in the command
-			execString = execString.replace(/"/g, "\\\"");
-
-			// Wrap the command in quotes if the entire option isn't going to be wrapped in quotes
-			if (document.getElementById("wrap_in_quotes").checked) {
-				resultString += ",exec=" + execString;
-			} else {
-				resultString += ",exec=\"" + execString + "\"";
-			}
+			resultString += ",exec=" + execString;
 		}
 		
 		// opts
@@ -708,21 +692,19 @@ function buildAndUpdateResult() {
 		resultString += ",file=";
 		var fileString = document.getElementById("file_text").value;
 		if (fileString != "") {
-			// Escape quotes in the filename
-			// (I'm not sure what sort of monster would put quotes in the filename, but hey)
-			fileString = fileString.replace(/"/g, "\\\"");
-
-			// Wrap the filename in quotes if the entire option isn't going to be wrapped in quotes
-			if (document.getElementById("wrap_in_quotes").checked) {
-				resultString += fileString;
-			} else {
-				resultString += "\"" + fileString + "\"";
-			}
+			resultString += fileString;
 		}
 	}
 
 	// Wrap in quotes if option checked
 	if (document.getElementById("wrap_in_quotes").checked) {
+		// Escape backslashes
+		resultString = resultString.replace(/\\/g, "\\\\");
+
+		// Escape quotes
+		resultString = resultString.replace(/"/g, "\\\"");
+
+		// Wrap the entire result string in quotes
 		resultString = "\"" + resultString + "\"";
 	}
 
@@ -1464,7 +1446,7 @@ ul {
 		<b><p id="result" style="font-size: 14pt; font-family:courier;">&nbsp;</p></b>
 		<hr>
 		<p>
-			<input type="checkbox" id="wrap_in_quotes" name="wrap_in_quotes" value="wrap_in_quotes" onchange="processChange(this)">
+			<input type="checkbox" id="wrap_in_quotes" name="wrap_in_quotes" value="wrap_in_quotes" onchange="processChange(this)" checked>
 			<label for="wrap_in_quotes">Wrap in quotes (for use in a shell)</label>
 		</p>
 		<p>

--- a/tools/xdump_option_builder.html
+++ b/tools/xdump_option_builder.html
@@ -762,10 +762,18 @@ function buildAndUpdateResult() {
 
 	// Check that a command has been specified if the tool agent is selected
 	var execElement = document.getElementById("exec");
-	if (document.getElementById("agent_tool").checked && execElement.value == "") {
-		resultIsGreen = false;
-		setErrorStyle(execElement);
-		errorsHtml += "ERROR: Shell command (tool) agent is checked, but no shell command has been specified<br>";		
+	if (document.getElementById("agent_tool").checked) {
+		if (execElement.value == "") {
+			resultIsGreen = false;
+			setErrorStyle(execElement);
+			errorsHtml += "ERROR: Shell command (tool) agent is checked, but no shell command has been specified<br>";
+		} else if (execElement.value.indexOf(",") != -1) {
+			resultIsGreen = false;
+			setErrorStyle(execElement);
+			errorsHtml += "ERROR: Invalid shell command: must not contain a comma.<br>";
+		} else {
+			unsetErrorStyle(execElement);
+		}
 	} else {
 		unsetErrorStyle(execElement);
 	}
@@ -785,28 +793,32 @@ function buildAndUpdateResult() {
 	if (!throwableClassElement.disabled) {
 		var classValue = throwableClassElement.value;
 		if (classValue.lastIndexOf("*") > 0) {
+			// Note: a filter containing a single wildcard at the beginning of the string,
+			// or a filter containing just a wildcard (i.e. "*") are fine
 			if (classValue.lastIndexOf("*") != (classValue.length - 1)) {
 				// Wildcard must be placed at the beginning and/or end of the string
 				resultIsGreen = false;
 				setErrorStyle(throwableClassElement);
-				errorsHtml += "ERROR: Exception class filter wildcards can only be used at the beginning and/or end of the filter<br>";
+				errorsHtml += "ERROR: Invalid Exception class filter: wildcards can only be used at the beginning and/or end of the filter<br>";
 			} else if (document.getElementById("event_throwable_method").value != "") {
 				// Wildcard not allowed at the end of the string if a method filter is enabled
 				resultIsGreen = false;
 				setErrorStyle(throwableClassElement);
-				errorsHtml += "ERROR: Exception class filter must not end with a wildcard when a method filter is specified<br>";
+				errorsHtml += "ERROR: Invalid Exception class filter: must not end with a wildcard when a method filter is specified<br>";
 			} else {
 				// Wildcard looks ok
 				unsetErrorStyle(throwableClassElement);
 			}
+		} else if (throwableClassElement.value.indexOf(",") != -1) {
+			resultIsGreen = false;
+			setErrorStyle(throwableClassElement);
+			errorsHtml += "ERROR: Invalid Exception class filter: must not contain a comma.<br>";
 		} else {
-			// No wildcard, or a single wildcard at the beginning of the string
-			// Note: A filter containing just a wildcard (i.e. "*") is also fine
 			unsetErrorStyle(throwableClassElement);
-		}		
+		}
 	}
 
-	// Check validity of any wildcard in the throwable method string	
+	// Check validity of the throwable method string	
 	var throwableMethodElement = document.getElementById("event_throwable_method");
 	if (!throwableMethodElement.disabled) {
 		var methodValue = throwableMethodElement.value;
@@ -815,20 +827,43 @@ function buildAndUpdateResult() {
 				// No wildcard allowed if using stack offset
 				resultIsGreen = false;
 				setErrorStyle(throwableMethodElement);
-				errorsHtml += "ERROR: Exception method filter must not contain a wildcard when using a stack offset.<br>";
+				errorsHtml += "ERROR: Invalid Exception method filter: must not contain a wildcard when using a stack offset.<br>";
 			} else if (methodValue.indexOf("*") != (methodValue.length - 1)) {
 				// If no stack offset, wildcard must be placed at the end
 				resultIsGreen = false;
 				setErrorStyle(throwableMethodElement);
-				errorsHtml += "ERROR: Exception method filter wildcard can only be used at the end of the filter<br>";
+				errorsHtml += "ERROR: Invalid Exception method filter: wildcard can only be used at the end of the filter<br>";
 			} else {
 				// Wildcard looks ok
 				unsetErrorStyle(throwableMethodElement);
 			}
+		} else if (throwableMethodElement.value.indexOf(",") != -1) {
+			resultIsGreen = false;
+			setErrorStyle(throwableMethodElement);
+			errorsHtml += "ERROR: Invalid Exception method filter: must not contain a comma.<br>";
 		} else {
-			// No wildcard
 			unsetErrorStyle(throwableMethodElement);
 		}
+	}
+
+	// Check validity of the throwable message filter string
+	var throwableMessageElement = document.getElementById("event_throwable_msg_filter");
+	if (throwableMessageElement.value.indexOf(",") != -1) {
+		resultIsGreen = false;
+		setErrorStyle(throwableMessageElement);
+		errorsHtml += "ERROR: Invalid Exception message filter: must not contain a comma.<br>";	
+	} else {
+		unsetErrorStyle(throwableMessageElement);
+	}
+
+	// Check validity of the class load/unload filter string
+	var classFilterElement = document.getElementById("event_class_filter");
+	if (classFilterElement.value.indexOf(",") != -1) {
+		resultIsGreen = false;
+		setErrorStyle(classFilterElement);
+		errorsHtml += "ERROR: Invalid class load/unload filter: must not contain a comma.<br>";	
+	} else {
+		unsetErrorStyle(classFilterElement);
 	}
 
 	// Check that a priority has been specified if the dump priority option is selected
@@ -848,6 +883,10 @@ function buildAndUpdateResult() {
 			resultIsGreen = false;
 			setErrorStyle(priorityValueElement);
 			errorsHtml += "ERROR: Dump file option is checked, but no file name has been specified<br>";
+		} else if (dumpFileElement.value.indexOf(",") != -1) {
+			resultIsGreen = false;
+			setErrorStyle(dumpFileElement);
+			errorsHtml += "ERROR: Invalid dump file name: must not contain a comma.<br>";
 		} else {
 			unsetErrorStyle(priorityValueElement);
 		}

--- a/tools/xdump_option_builder.html
+++ b/tools/xdump_option_builder.html
@@ -789,6 +789,7 @@ function buildAndUpdateResult() {
 	}
 
 	// Check validity of the throwable class string
+	var throwableClassHasError = false;
 	var throwableClassElement = document.getElementById("event_throwable_class")
 	if (!throwableClassElement.disabled) {
 		var classValue = throwableClassElement.value;
@@ -797,50 +798,53 @@ function buildAndUpdateResult() {
 			// or a filter containing just a wildcard (i.e. "*") are fine
 			if (classValue.lastIndexOf("*") != (classValue.length - 1)) {
 				// Wildcard must be placed at the beginning and/or end of the string
-				resultIsGreen = false;
-				setErrorStyle(throwableClassElement);
+				throwableClassHasError = true;
 				errorsHtml += "ERROR: Invalid Exception class filter: wildcards can only be used at the beginning and/or end of the filter<br>";
 			} else if (document.getElementById("event_throwable_method").value != "") {
 				// Wildcard not allowed at the end of the string if a method filter is enabled
-				resultIsGreen = false;
-				setErrorStyle(throwableClassElement);
+				throwableClassHasError = true
 				errorsHtml += "ERROR: Invalid Exception class filter: must not end with a wildcard when a method filter is specified<br>";
-			} else {
-				// Wildcard looks ok
-				unsetErrorStyle(throwableClassElement);
 			}
-		} else if (throwableClassElement.value.indexOf(",") != -1) {
+		}
+		
+		if (throwableClassElement.value.indexOf(",") != -1) {
+			throwableClassHasError = true;
+			errorsHtml += "ERROR: Invalid Exception class filter: must not contain a comma.<br>";
+		} 
+		
+		if (throwableClassHasError) {
 			resultIsGreen = false;
 			setErrorStyle(throwableClassElement);
-			errorsHtml += "ERROR: Invalid Exception class filter: must not contain a comma.<br>";
 		} else {
 			unsetErrorStyle(throwableClassElement);
 		}
 	}
 
 	// Check validity of the throwable method string	
+	var throwableMethodHasError = false;
 	var throwableMethodElement = document.getElementById("event_throwable_method");
 	if (!throwableMethodElement.disabled) {
 		var methodValue = throwableMethodElement.value;
 		if (methodValue.indexOf("*") != -1) {
 			if (document.getElementById("event_throwable_offset").value != "0") {
 				// No wildcard allowed if using stack offset
-				resultIsGreen = false;
-				setErrorStyle(throwableMethodElement);
+				throwableMethodHasError = true;
 				errorsHtml += "ERROR: Invalid Exception method filter: must not contain a wildcard when using a stack offset.<br>";
 			} else if (methodValue.indexOf("*") != (methodValue.length - 1)) {
 				// If no stack offset, wildcard must be placed at the end
-				resultIsGreen = false;
-				setErrorStyle(throwableMethodElement);
+				throwableMethodHasError = true;
 				errorsHtml += "ERROR: Invalid Exception method filter: wildcard can only be used at the end of the filter<br>";
-			} else {
-				// Wildcard looks ok
-				unsetErrorStyle(throwableMethodElement);
 			}
-		} else if (throwableMethodElement.value.indexOf(",") != -1) {
+		}
+		
+		if (throwableMethodElement.value.indexOf(",") != -1) {
+			throwableMethodHasError = true;
+			errorsHtml += "ERROR: Invalid Exception method filter: must not contain a comma.<br>";
+		} 
+		
+		if (throwableMethodHasError) {
 			resultIsGreen = false;
 			setErrorStyle(throwableMethodElement);
-			errorsHtml += "ERROR: Invalid Exception method filter: must not contain a comma.<br>";
 		} else {
 			unsetErrorStyle(throwableMethodElement);
 		}

--- a/tools/xtrace_option_builder.html
+++ b/tools/xtrace_option_builder.html
@@ -1513,7 +1513,13 @@ function buildAndUpdateResult() {
 	// TODO: This doesn't work properly on Linux if there is an '!' in a method/tpnid field
 	//       Single quotes don't work on Windows...
 	if (document.getElementById("wrap_in_quotes").checked) {
-		// Then wrap the entire result string in quotes
+		// Escape backslashes
+		resultString = resultString.replace(/\\/g, "\\\\");
+		
+		// Escape quotes
+		resultString = resultString.replace(/"/g, "\\\"");
+		
+		// Wrap the entire result string in quotes
 		resultString = "\"" + resultString + "\"";
 	}
 
@@ -2141,16 +2147,8 @@ function getOutputResultString() {
 	if (!fileElement.disabled) {
 		var fileString = fileElement.value;
 		if (fileString != "") {
-			// Escape quotes in the filename
-			// (I'm not sure what sort of monster would put quotes in the filename, but hey)
-			fileString = fileString.replace(/"/g, "\\\"");
-
-			// Wrap the filename in quotes if the entire option isn't going to be wrapped in quotes
-			if (document.getElementById("wrap_in_quotes").checked) {
-				regularOutputString += fileString + ",";
-			} else {
-				regularOutputString += "\"" + fileString + "\",";
-			}
+			// File name
+			regularOutputString += fileString + ",";
 
 			// Max size and generations
 			var maxSize = document.getElementById("output_size").value;
@@ -2172,18 +2170,8 @@ function getOutputResultString() {
 	// This field is *mandatory* if the Exception destination is selected
 	fileElement = document.getElementById("file_text_exception");
 	if (!fileElement.disabled) {
-		var fileString = fileElement.value;
-
-		// Escape quotes in the filename
-		// (I'm not sure what sort of monster would put quotes in the filename, but hey)
-		fileString = fileString.replace(/"/g, "\\\"");
-
-		// Wrap the filename in quotes if the entire option isn't going to be wrapped in quotes
-		if (document.getElementById("wrap_in_quotes").checked) {
-			exceptionOutputString += fileString + ",";
-		} else {
-			exceptionOutputString += "\"" + fileString + "\",";
-		}
+		// File name
+		exceptionOutputString += fileElement.value + ",";
 
 		// Maximum size
 		var maxSize = document.getElementById("output_size_exception").value;

--- a/tools/xtrace_option_builder.html
+++ b/tools/xtrace_option_builder.html
@@ -1356,17 +1356,21 @@ function fixTracepointIdCase(id) {
 		"Audio"
 	];
 
-	// If the specified component matches an component in the table (case insensitive match), return the correct form
-	var idArray = id.split(".");
-	var component = idArray[0];
-	var tracepointNumber = idArray[1];
-	for (var i = 0; i < knownComponents.length; i++) {
-		if (component.toLowerCase() == knownComponents[i].toLowerCase()) {
-			return knownComponents[i] + "." + tracepointNumber;
+	// If the ID looks valid and the specified component matches an component in the table
+	// (case insensitive match), return the correct form
+	if (id.match(/^([a-zA-Z0-9])+\.\d+(-\d+)?$/) != null) {
+		var idArray = id.split(".");
+		var component = idArray[0];
+		var tracepointNumber = idArray[1];
+		for (var i = 0; i < knownComponents.length; i++) {
+			if (component.toLowerCase() == knownComponents[i].toLowerCase()) {
+				return knownComponents[i] + "." + tracepointNumber;
+			}
 		}
 	}
 
-	// If we reach here the ID contains an unknown component, so just return it without making any changes
+	// If we reach here the tracepoint ID is either invalid or contains an unknown component,
+	// so just return it without making any changes
 	return id;
 }
 
@@ -1579,12 +1583,16 @@ function buildAndUpdateResult() {
 	for (var i = 0; i < methodCounter; i++) {
 		var methodSpecElement = document.getElementById("meth_text_" + i);
 
-		// Check that each method option actually contains a method spec
+		// Check that each method option actually contains a valid-looking method spec
 		if (methodSpecElement != null) {
 			if (methodSpecElement.value == "") {
 				resultIsGreen = false;
 				setErrorStyle(methodSpecElement);
 				errorsHtml += "ERROR: Missing method specification in method trace<br>";
+			} else if (methodSpecElement.value.indexOf(",") != -1) {
+				resultIsGreen = false;
+				setErrorStyle(methodSpecElement);
+				errorsHtml += "ERROR: Invalid method specification: must not contain a comma: \"" + escapeHTML(methodSpecElement.value) + "\"<br>";
 			} else {
 				unsetErrorStyle(methodSpecElement);
 			}
@@ -1651,14 +1659,21 @@ function buildAndUpdateResult() {
 				// Method spec is present
 				unsetErrorStyle(methodSpecElement);
 
+				// Check whether the method spec looks valid
+				if (methodSpecElement.value.indexOf(",") != -1) {
+					resultIsGreen = false;
+					setErrorStyle(methodSpecElement);
+					errorsHtml += "ERROR: Invalid method specification: must not contain a comma: \"" + escapeHTML(methodSpecElement.value) + "\"<br>";
+				}
+
 				// Check that an entry or exit action is provided
 				var entryActionElement = getSelectedElement(document.getElementById("trig_meth_ent_" + i));
 				var exitActionElement = getSelectedElement(document.getElementById("trig_meth_ex_" + i));
 				if (entryActionElement.value == "none" && exitActionElement.value == "none") {
-						resultIsGreen = false;
+					resultIsGreen = false;
 					setErrorStyle(entryActionElement);
 					setErrorStyle(exitActionElement);
-					errorsHtml += "ERROR: No entry/exit action selected for method trigger: " + methodSpecElement.value + "<br>";
+					errorsHtml += "ERROR: No entry/exit action selected for method trigger: " + escapeHTML(methodSpecElement.value) + "<br>";
 				} else {
 					unsetErrorStyle(entryActionElement);
 					unsetErrorStyle(exitActionElement);
@@ -1753,8 +1768,16 @@ function buildAndUpdateResult() {
 		if (!isOutputFileSpecified()) {
 			// Warning only - output file is not manadatory
 			warningsHtml += "WARNING: No output file specified for trace buffers (trace will still be visible in snap dumps)<br>";
-		} else if (containsReservedChars(fileTextElement.value)) {
-			warningsHtml += "WARNING: Trace buffer output file contains a character that is disallowed on some platforms<br>";
+		} else if (fileTextElement.value.indexOf(",") != -1) {
+			resultIsGreen = false;
+			setErrorStyle(fileTextElement);
+			errorsHtml += "ERROR: Invalid trace buffer output file name: must not contain a comma.<br>";
+		} else {
+			unsetErrorStyle(fileTextElement);
+		}
+		
+		if (containsReservedChars(fileTextElement.value)) {
+			warningsHtml += "WARNING: Trace buffer output file name contains a character that is disallowed on some platforms<br>";
 		}
 	}
 	var exceptionFileTextElement = document.getElementById("file_text_exception");
@@ -1764,12 +1787,16 @@ function buildAndUpdateResult() {
 			resultIsGreen = false;
 			setErrorStyle(exceptionFileTextElement);
 			errorsHtml += "ERROR: No output file specified for Exception trace buffers<br>";
+		} else if (exceptionFileTextElement.value.indexOf(",") != -1) {
+			resultIsGreen = false;
+			setErrorStyle(fileTextElement);
+			errorsHtml += "ERROR: Invalid Exception trace buffer output file name: must not contain a comma.<br>";
 		} else {
 			unsetErrorStyle(exceptionFileTextElement);
 		}
 
 		if (containsReservedChars(exceptionFileTextElement.value)) {
-			warningsHtml += "WARNING: Exception trace buffer output file contains a character that is disallowed on some platforms<br>";
+			warningsHtml += "WARNING: Exception trace buffer output file name contains a character that is disallowed on some platforms<br>";
 		}
 	} else {
 		unsetErrorStyle(exceptionFileTextElement);

--- a/tools/xtrace_option_builder.html
+++ b/tools/xtrace_option_builder.html
@@ -1656,14 +1656,13 @@ function buildAndUpdateResult() {
 				setErrorStyle(methodSpecElement);
 				errorsHtml += "ERROR: Missing method specification in trigger<br>";
 			} else {
-				// Method spec is present
-				unsetErrorStyle(methodSpecElement);
-
 				// Check whether the method spec looks valid
 				if (methodSpecElement.value.indexOf(",") != -1) {
 					resultIsGreen = false;
 					setErrorStyle(methodSpecElement);
 					errorsHtml += "ERROR: Invalid method specification: must not contain a comma: \"" + escapeHTML(methodSpecElement.value) + "\"<br>";
+				} else {
+					unsetErrorStyle(methodSpecElement);
 				}
 
 				// Check that an entry or exit action is provided
@@ -1768,17 +1767,19 @@ function buildAndUpdateResult() {
 		if (!isOutputFileSpecified()) {
 			// Warning only - output file is not manadatory
 			warningsHtml += "WARNING: No output file specified for trace buffers (trace will still be visible in snap dumps)<br>";
-		} else if (fileTextElement.value.indexOf(",") != -1) {
+		} else if (containsReservedChars(fileTextElement.value)) {
+			warningsHtml += "WARNING: Trace buffer output file name contains a character that is disallowed on some platforms<br>";
+		}
+
+		// We have to do this separately (instead of in an else if) to ensure that the
+		// error style always gets unset after removing the comma
+		if (fileTextElement.value.indexOf(",") != -1) {
 			resultIsGreen = false;
 			setErrorStyle(fileTextElement);
 			errorsHtml += "ERROR: Invalid trace buffer output file name: must not contain a comma.<br>";
 		} else {
 			unsetErrorStyle(fileTextElement);
-		}
-		
-		if (containsReservedChars(fileTextElement.value)) {
-			warningsHtml += "WARNING: Trace buffer output file name contains a character that is disallowed on some platforms<br>";
-		}
+		}	
 	}
 	var exceptionFileTextElement = document.getElementById("file_text_exception");
 	if (!exceptionFileTextElement.disabled) {


### PR DESCRIPTION
Some further improvements to the Option Builder tools as discussed [here ](https://github.com/eclipse/openj9-website/pull/165#issuecomment-479102728)and [here](https://github.com/eclipse/openj9-website/pull/165#issuecomment-479554161).

1. The "wrap in quotes" option is now on by default for the Xdump tool, to bring it in line with the Xtrace tool.
2.  Filenames/filters and other strings containing user input are no longer enclosed in quotes when "wrap in quotes" is disabled.
3. Xdump/Xtrace suboption strings cannot contain commas, even when quoted. The tools now detect problematic commas in user input and print errors.