### PR TITLE
Restore modified oj9_joinslack.html page

### DIFF
--- a/oj9_joinslack.html
+++ b/oj9_joinslack.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2017, 2019 IBM Corp. and others
+
+This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution and is available at http://eclipse.org/legal/epl-2.0 or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0. 
+
+This Source Code may also be made available under the following Secondary Licenses when the conditions for such availability set forth in the Eclipse Public License, v. 2.0 are satisfied: GNU General Public License, version 2 with the GNU Classpath Exception [1] and GNU General Public License, version 2 with the OpenJDK Assembly Exception [2]. 
+
+[1] https://www.gnu.org/software/classpath/license.html  
+[2] http://openjdk.java.net/legal/assembly-exception.html 
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+The project website pages cannot be redistributed
+-->
+  <script type="text/javascript" src="./js/oj9_common.js"></script>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>OpenJ9 - Join slack</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.css">
+  <link rel="stylesheet" href="./css/oj9_media.css">
+  <link rel="stylesheet" href="./css/oj9_common.css">
+<!-- Eclipse privacy popup -->
+  <link rel="stylesheet" type="text/css" href="//www.eclipse.org/eclipse.org-common/themes/solstice/public/stylesheets/vendor/cookieconsent/cookieconsent.min.css" />  
+  <script type="text/javascript" src="./js/oj9_common.js"></script>
+<!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-5WLCZXC');</script>
+<!-- End Google Tag Manager --> 
+</head>
+<body>
+  <div id="main-title">
+    <script type="text/javascript">navigation(document.location.href);</script>	
+    <div class="title">
+      <a href="index.html">
+        <!--<img class="title_icon" src="./assets/openj9_6a.png" alt="Eclipse OpenJ9">-->
+    	  <img class="title_icon" src="./assets/openj9_6b.png" alt="Eclipse OpenJ9">
+      </a>
+    </div>  
+    <div class="egg">
+      <a href="http://wiki.eclipse.org/Development_Resources/Process_Guidelines/What_is_Incubation" target="_blank"><img src="./assets/egg-incubation.png" alt="Eclipse Incubation"></a>
+    </div>  
+  </div>
+
+  <main>
+
+    <div id="joinslack" class="section-content">
+      <h1>Join our Slack community channel</h1>
+
+      <div class="f-section-item">
+        <span class="intro-text"><a href="https://join.slack.com/t/openj9/shared_invite/enQtNDU4MDI4Mjk0MTk2LWM2MjliMTQ4NWM5YjMwNTViOTgzMzM2ZDhlOWJmZTc1MjhmYmRjMDg2NDljNGM0YTAwOWRiZDE0YzI0NjgyOWIs">Click here</a></span>
+      </div>
+    
+
+    </div> <!-- end: build -->
+
+  </main>
+
+  <footer>
+	<div class="social-icon">
+      <a href="https://github.com/eclipse/openj9" target="_blank" title="Github">
+        <i class="fa fa-github" aria-hidden="true" style="font-size: 2.3rem;"></i>
+      </a>
+    </div>
+    <div class="social-icon">
+      <a href="https://openj9.slack.com/" target="_blank" title="Slack">
+      	<i class="fa fa-slack" aria-hidden="true" style="font-size:2rem;"></i>
+      </a>
+    </div>
+	<div class="social-icon">
+      <a href="https://twitter.com/openj9/" target="_blank" title="Twitter">
+      	<i class="fa fa-twitter" aria-hidden="true" style="font-size:2rem;"></i>
+      </a>
+    </div>
+    <div class="social-icon">
+      <a href="https://stackoverflow.com/search?q=%23OpenJ9" target="_blank" title="Stack Overflow">
+        <i class="fa fa-stack-overflow" aria-hidden="true" style="font-size: 2rem;"></i>
+      </a>
+    </div>
+
+    <p>OpenJ9 is an Eclipse Incubator project.</p>
+    
+    <span class="no-wrap"><i class="fa fa-chevron-circle-right f_mini" aria-hidden="true"></i><a class="dark-link" href="http://www.eclipse.org">Eclipse Foundation website</a></span>
+    <span class="no-wrap"><i class="fa fa-chevron-circle-right f_mini" aria-hidden="true"></i><a class="dark-link" href="http://www.eclipse.org/legal/privacy.php">Privacy policy</a></span>
+    <span class="no-wrap"><i class="fa fa-chevron-circle-right f_mini" aria-hidden="true"></i><a class="dark-link" href="http://www.eclipse.org/legal/termsofuse.php">Website terms&nbsp;of use</a></span>
+    <span class="no-wrap"><i class="fa fa-chevron-circle-right f_mini" aria-hidden="true"></i><a class="dark-link" href="http://www.eclipse.org/legal/copyright.php">Copyright agent</a></span>
+    <span class="no-wrap"><i class="fa fa-chevron-circle-right f_mini" aria-hidden="true"></i><a class="dark-link" href="http://www.eclipse.org/legal">Legal</a></span>
+
+  </footer>
+
+  <script src="./js/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
After we changed the way we invite people to slack, the
old page was taken down. However, a google search
for OpenJ9 slack puts this old page at the top of the list.

Restored the page but replaced the original content with the
new invitation link.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>