### PR TITLE
Enable "Disable default tracepoints" option for exception buffers

### DIFF
--- a/tools/xtrace_option_builder.html
+++ b/tools/xtrace_option_builder.html
@@ -473,11 +473,11 @@ function processChange(option) {
 		option.value = result;
 	}
 
-	// Enable the disable_predefined checkbox if we are tracing to maximal buffers,
-	// and disabled otherwise. This is because the tracepoints that are enabled by
-	// default are traced to maximal buffers. We only care about them if we're
-	// tracing to the dame destination.
-	if (isMaximalTracepointDestinationEnabled()) {
+	// Enable the disable_predefined checkbox if we are tracing to maximal or
+	// exception buffers, and disabled otherwise. This is because only these two destinations
+	// have tracepoints enabled by default, and we only care about them if we're tracing to
+	// the same destination.
+	if (isMaximalOrExceptionDestinationEnabled()) {
 		enableInput(document.getElementById("disable_predefined"));
 	} else {
 		disableInput(document.getElementById("disable_predefined"));
@@ -1274,14 +1274,17 @@ function isIdTracepointEnabled(specifiedId) {
 	return false;
 }
 
-// Returns true if the "maximal" tracepoint destination is enabled
-function isMaximalTracepointDestinationEnabled() {
+// Returns true if the "maximal" or "exception" tracepoint destinations are enabled
+function isMaximalOrExceptionDestinationEnabled() {
 	for (var i = 0; i < tracepointCounter; i++) {
-		if (document.getElementById("tp_dest_maximal_" + i) != null) {
-			if (document.getElementById("tp_dest_maximal_" + i).selected) {
-				return true;
-			}
-		}
+		var maxDestElement = document.getElementById("tp_dest_maximal_" + i);
+		var excDestElement = document.getElementById("tp_dest_exception_" + i);		
+		if (maxDestElement != null && maxDestElement.selected) {
+			return true;
+		}	
+		if (excDestElement != null && excDestElement.selected) {
+			return true;
+		}		
 	}
 	return false;
 }
@@ -2650,8 +2653,8 @@ The project website pages cannot be redistributed
 		</td>
 		<td>
 			&nbsp;
-			<input disabled type="checkbox" id="disable_predefined" name="disable_predefined" value="disable_predefined" title="Disables all tracepoints that are enabled by default" checked onchange="processChange(this)">
-			<label data-disabled="true" for="disable_predefined" title="Disables all tracepoints that are enabled by default (destination: maximal buffers)">Disable default tracepoints</label>
+			<input disabled type="checkbox" id="disable_predefined" name="disable_predefined" value="disable_predefined" title="Disables all tracepoints that are enabled by default for applicable destinations:&#10;    - Maximal buffers:  all Level 1 and Level 2 tracepoints&#10;    - Exception buffers:  verbose GC logging tracepoints" checked onchange="processChange(this)">
+			<label data-disabled="true" for="disable_predefined" title="Disables all tracepoints that are enabled by default for applicable destinations:&#10;    - Maximal buffers:  all Level 1 and Level 2 tracepoints&#10;    - Exception buffers:  verbose GC logging tracepoints">Disable default tracepoints</label>
 		</td>
 	</tr>
 </table>


### PR DESCRIPTION
By default the Xtrace engine has all level 1 and level 2 tracepoints enabled, with output going to the maximal trace buffers. The Xtrace Option Builder's _Disable default tracepoints_ option, when checked, adds the `none `sub-option to the Xtrace option to disable these tracepoints. Right now the _Disable default tracepoints_ option is only enabled if the user has chosen maximal trace buffers as the destination for any of their tracepoints.

However, the exception buffers need this option as well, because all `gclogger` tracepoints (i.e. verbose GC data) are sent to this destination by default, and the user may want to disable them if they are targeting the exception buffers with their Xtrace option. The changes in this PR enable the _Disable default tracepoints_ option when exception buffers are in use. The option is checked by default, which matches the current behaviour for maximal buffers.

Signed-off-by: Paul Cheeseman <paul.cheeseman@uk.ibm.com>