### PR TITLE
Minor layout improvements for Option Builders

### DIFF
--- a/tools/xdump_option_builder.html
+++ b/tools/xdump_option_builder.html
@@ -1237,13 +1237,10 @@ label[data-disabled=false] {
 	color: #000;
 }
 
-td {
-	vertical-align: top;
-}
-
 ul {
 	list-style-type: none;
 	padding: 0px;
+	margin-block-end: 0;
 }
 
 </style>
@@ -1256,7 +1253,7 @@ ul {
 
 <form id="XdumpForm" name="XdumpForm" onsubmit="event.preventDefault(); return handleSubmit()">
 
-<table border="0" cellspacing="0" cellpadding="4" style="width:1150px; table-layout:fixed">
+<table border="0" cellspacing="0" cellpadding="5" style="width:1150px; table-layout:fixed">
 <tr>
 	<td  class="head1" colspan="2">
 	OpenJ9: Xdump Option Builder
@@ -1264,10 +1261,10 @@ ul {
 </tr>
 
 <tr>
-	<td rowspan="2">	
+	<td style="vertical-align: top;" rowspan="2">	
 		<b style="font-size: 12pt">Dump Events</b>
+		<hr>
 		<ul id="event_input">
-			<hr>
 			<li>
 				<input type="checkbox" id="event_user"         name="event" value="user"        onchange="processChange(this)" data-hasfilter="false">
 				<label for="event_user">User signal i.e. SIGQUIT ("kill -3") / SIGBREAK</label>
@@ -1403,10 +1400,10 @@ ul {
 		</ul>
 	</td>
 
-	<td>
+	<td style="vertical-align: top;">
 		<b style="font-size: 12pt">Dump Agents</b>
+		<hr>
 		<ul id="agent_input">
-			<hr>
 			<li>
 				<input type="checkbox" id="agent_stack"   name="agent" value="stack"   onchange="processChange(this)">
 				<label for="agent_stack">Write current Java&trade; thread stack to stderr</label>
@@ -1443,7 +1440,7 @@ ul {
 			<li>
 				<input type="checkbox" id="agent_tool"    name="agent" value="tool"    onchange="processChange(this)" onmousedown="registerToolExecMouseDown()">
 				<label for="agent_tool" onmousedown="registerToolExecMouseDown()">Run a shell command:</label><br> 
-				<input style="width: 565px" type="text" id="exec" name="exec" size="72" value="" disabled onchange="processChange(this)" onblur="processChange(this)">
+				<input style="width: 558px" type="text" id="exec" name="exec" size="71" value="" disabled onchange="processChange(this)" onblur="processChange(this)">
 				<div style="padding: 4px 0px;">
 					<input type="button" data-target="exec" data-token="%Y"    id="exec_button_year4"  disabled style="width:55px" onclick="processChange(this)"
 						onmousedown="registerToolExecMouseDown()" value="Year (4)" title="Year (4 digits) e.g. 2017">
@@ -1499,8 +1496,8 @@ ul {
 <tr>
 	<td>
 		<b style="font-size: 12pt">Dump Options</b>
+		<hr>
 		<ul id="options_input">
-			<hr>
 			<div id="request_input">
 				<li>
 					<input type="checkbox" id="request_exclusive" name="request" value="exclusive" onchange="processChange(this)">
@@ -1541,11 +1538,11 @@ ul {
 			<hr>
 			<li>
 				<label for="file_text" data-disabled="true">Dump file pattern (all dumps except SYSTDUMPs and CEEDUMPs):</label> 
-				<input style="width: 565px" type="text" id="file_text" name="file_text" size="71" value="" disabled onchange="processChange(this)" onblur="registerTokenTarget(this)">
+				<input style="width: 558px" type="text" id="file_text" name="file_text" size="71" value="" disabled onchange="processChange(this)" onblur="registerTokenTarget(this)">
 			</li>
 			<li>
 				<label for="dsn_text" data-disabled="true">Data set pattern (SYSTDUMPs only):</label> 
-				<input style="width: 565px" type="text" id="dsn_text" name="dsn_text" size="71" value="" disabled onchange="processChange(this)" onblur="registerTokenTarget(this)">
+				<input style="width: 558px" type="text" id="dsn_text" name="dsn_text" size="71" value="" disabled onchange="processChange(this)" onblur="registerTokenTarget(this)">
 			</li>
 			<li>
 				<div style="padding: 4px 0px;">

--- a/tools/xdump_option_builder.html
+++ b/tools/xdump_option_builder.html
@@ -1253,7 +1253,7 @@ ul {
 
 <form id="XdumpForm" name="XdumpForm" onsubmit="event.preventDefault(); return handleSubmit()">
 
-<table border="0" cellspacing="0" cellpadding="5" style="width:1150px; table-layout:fixed">
+<table border="0" cellspacing="0" cellpadding="4" style="width:1150px; table-layout:fixed">
 <tr>
 	<td  class="head1" colspan="2">
 	OpenJ9: Xdump Option Builder

--- a/tools/xtrace_option_builder.html
+++ b/tools/xtrace_option_builder.html
@@ -2638,7 +2638,7 @@ The project website pages cannot be redistributed
 </tr>
 </tbody>
 </table>
-<br/><br/>
+<br/>
 
 <table cellpadding="1">
 	<tr>
@@ -2757,7 +2757,7 @@ The project website pages cannot be redistributed
 			<label data-disabled="true" for="file_text">Regular output file name:</label>
 		</td>
 		<td>
-			<input disabled type="text" id="file_text" name="file_text" size="30" value="" onchange="processChange(this)" onblur="processChange(this)">
+			<input disabled type="text" id="file_text" name="file_text" size="40" value="" onchange="processChange(this)" onblur="processChange(this)">
 		</td>
 		<td>
 			<input disabled type="button" data-target="file_text" data-token="%p" id="file_button_pid"  style="font-size: 8pt; height:23px;width:45px" onclick="processChange(this)"
@@ -2796,7 +2796,7 @@ The project website pages cannot be redistributed
 			<label data-disabled="true" for="file_text_exception">Exception output file name:</label>
 		</td>
 		<td>
-			<input disabled type="text" id="file_text_exception" name="file_text_exception" size="30" value="" onchange="processChange(this)" onblur="processChange(this)">
+			<input disabled type="text" id="file_text_exception" name="file_text_exception" size="40" value="" onchange="processChange(this)" onblur="processChange(this)">
 		</td>
 		<td>
 			<input disabled type="button" data-target="file_text_exception" data-token="%p" id="file_button_pid_exception"  style="font-size: 8pt; height:23px;width:45px" onclick="processChange(this)"


### PR DESCRIPTION
Xdump Option Builder:
- Vertically aligned `<td>` elements to top
- Moved a couple of `<hr>` elements so that they are a nicer width
- Reduced the width of the tool/file/dsn text fields slightly so that they fit inside the table
- Removed unnecessary trailing margin for `<ul>` elements.
- ~Slightly increased cell padding~ (I undid this change because it breaks other parts of the layout)

Xtrace Option Builder:
- Removed unnecessary line break between the title and the Tracepoints section
- Increased width of file name fields

Signed-off-by: Paul Cheeseman <paul.cheeseman@uk.ibm.com>