### PR TITLE
Move Google global site tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,16 @@ The project website pages cannot be redistributed
 -->
 <html lang="en">
 <head>
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-105616558-3"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'UA-105616558-3', { 'anonymize_ip': true });
+  </script>
+   <!-- End Global site tag (gtag.js) - Google Analytics -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
@@ -29,16 +39,6 @@ The project website pages cannot be redistributed
   <script src="//www.eclipse.org/eclipse.org-common/themes/solstice/public/javascript/vendor/cookieconsent/default.min.js"></script>
   <!-- End Eclipse privacy popup -->
 <script type="text/javascript" src="./js/oj9_common.js"></script>
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-105616558-3"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'UA-105616558-3', { 'anonymize_ip': true });
-</script>
- <!-- End Global site tag (gtag.js) - Google Analytics -->
 </head>
 <body>
   <div id="main-title">

--- a/oj9_build.html
+++ b/oj9_build.html
@@ -15,6 +15,16 @@ The project website pages cannot be redistributed
 -->
 <html lang="en">
 <head>
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-105616558-3"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'UA-105616558-3', { 'anonymize_ip': true });
+  </script>
+   <!-- End Global site tag (gtag.js) - Google Analytics -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
@@ -29,16 +39,6 @@ The project website pages cannot be redistributed
   <script src="//www.eclipse.org/eclipse.org-common/themes/solstice/public/javascript/vendor/cookieconsent/default.min.js"></script>
   <!-- End Eclipse privacy popup -->
   <script type="text/javascript" src="./js/oj9_common.js"></script>
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-105616558-3"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'UA-105616558-3', { 'anonymize_ip': true });
-</script>
- <!-- End Global site tag (gtag.js) - Google Analytics -->
 </head>
 
 <body onload="version('a')">

--- a/oj9_faq.html
+++ b/oj9_faq.html
@@ -17,6 +17,16 @@ The project website pages cannot be redistributed
 -->
 <html lang="en">
 <head>
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-105616558-3"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'UA-105616558-3', { 'anonymize_ip': true });
+  </script>
+   <!-- End Global site tag (gtag.js) - Google Analytics -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
@@ -31,16 +41,6 @@ The project website pages cannot be redistributed
   <script src="//www.eclipse.org/eclipse.org-common/themes/solstice/public/javascript/vendor/cookieconsent/default.min.js"></script>
   <!-- End Eclipse privacy popup -->
  <script type="text/javascript" src="./js/oj9_common.js"></script>
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-105616558-3"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'UA-105616558-3', { 'anonymize_ip': true });
-</script>
- <!-- End Global site tag (gtag.js) - Google Analytics -->
 </head>
 <body>
   <div id="main-title">

--- a/oj9_performance.html
+++ b/oj9_performance.html
@@ -16,6 +16,16 @@ The project website pages cannot be redistributed
 -->
 <html lang="en">
 <head>
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-105616558-3"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'UA-105616558-3', { 'anonymize_ip': true });
+  </script>
+   <!-- End Global site tag (gtag.js) - Google Analytics -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
@@ -30,16 +40,6 @@ The project website pages cannot be redistributed
   <script src="//www.eclipse.org/eclipse.org-common/themes/solstice/public/javascript/vendor/cookieconsent/default.min.js"></script>
   <!-- End Eclipse privacy popup -->
   <script type="text/javascript" src="./js/oj9_common.js"></script>
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-105616558-3"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'UA-105616558-3', { 'anonymize_ip': true });
-</script>
- <!-- End Global site tag (gtag.js) - Google Analytics -->
 </head>
 <body>
   <div id="main-title">

--- a/oj9_resources.html
+++ b/oj9_resources.html
@@ -15,6 +15,16 @@ The project website pages cannot be redistributed
 -->
 <html lang="en">
 <head>
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-105616558-3"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'UA-105616558-3', { 'anonymize_ip': true });
+  </script>
+   <!-- End Global site tag (gtag.js) - Google Analytics -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
@@ -29,16 +39,6 @@ The project website pages cannot be redistributed
   <link rel="stylesheet" type="text/css" href="//www.eclipse.org/eclipse.org-common/themes/solstice/public/stylesheets/vendor/cookieconsent/cookieconsent.min.css" />
   <script src="//www.eclipse.org/eclipse.org-common/themes/solstice/public/javascript/vendor/cookieconsent/default.min.js"></script>
   <!-- End Eclipse privacy popup -->
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-105616558-3"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'UA-105616558-3', { 'anonymize_ip': true });
-</script>
- <!-- End Global site tag (gtag.js) - Google Analytics -->
 </head>
 <body>
   <div id="main-title">

--- a/oj9_whatsnew.html
+++ b/oj9_whatsnew.html
@@ -16,6 +16,16 @@ The project website pages cannot be redistributed
 -->
 <html lang="en">
 <head>
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-105616558-3"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'UA-105616558-3', { 'anonymize_ip': true });
+  </script>
+   <!-- End Global site tag (gtag.js) - Google Analytics -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
@@ -36,16 +46,6 @@ The project website pages cannot be redistributed
   <script src="//www.eclipse.org/eclipse.org-common/themes/solstice/public/javascript/vendor/cookieconsent/default.min.js"></script>
   <!-- End Eclipse privacy popup -->
   <script type="text/javascript" src="./js/oj9_common.js"></script>
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-105616558-3"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'UA-105616558-3', { 'anonymize_ip': true });
-</script>
- <!-- End Global site tag (gtag.js) - Google Analytics -->
  <!-- Disable twitter web intent -->
  <!--<script>window.twttr = (function(d, s, id) {
   var js, fjs = d.getElementsByTagName(s)[0],


### PR DESCRIPTION
Issues with obtaining GA data. Instructions insist
the tag is immediately under <HEAD>. Moving to see
if this fixes the problem.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>