### PR TITLE
Fix minor Xtrace Option Builder issues involving suspend/resume

### DIFF
--- a/tools/xtrace_option_builder.html
+++ b/tools/xtrace_option_builder.html
@@ -1788,8 +1788,8 @@ function buildAndUpdateResult() {
 				if (!document.getElementById("trace_initially_disabled").checked && !isTriggerActionSelected("suspendthis")) {
 					errorsHtml += "WARNING: Trigger action \"Start tracing (current thread)\" is enabled, but tracing for the current thread is never disabled. Did you mean to check the \"Trace initially stopped\" option or add a \"Stop trace (current thread)\" trigger action?<br>";
 				}				
-			} else {
-				// Must be "resume"
+			}
+			if (isTriggerActionSelected("resume")) {
 				if (!document.getElementById("trace_initially_disabled").checked && !isTriggerActionSelected("suspend")) {
 					errorsHtml += "WARNING: Trigger action \"Start tracing (all threads)\" is enabled, but tracing for all threads is never disabled. Did you mean to check the \"Trace initially stopped\" option or add a \"Stop trace (all threads)\" trigger action?<br>";
 				}
@@ -2209,10 +2209,13 @@ function getTriggerResultString() {
 			// resume must be paired with suspend
 			triggerString = "suspend," + triggerString;
 		}
-		
 		if (resumethisActionSelected) {
 			// resumethis must be paired with resumecount=1
 			triggerString = "resumecount=1," + triggerString;
+		}
+		if (!resumeActionSelected && !resumethisActionSelected) {
+			// If no resume* actions are enabled, use "suspend" (we could use either)
+			triggerString = "suspend," + triggerString;
 		}
 	}
 


### PR DESCRIPTION
This PR fixes a couple of minor bugs introduced by my last commit:

- Selecting "Trace initially stopped" didn't actually add a trace-disabling option to the result unless a "Start trace" trigger action was also selected. The `suspend` option is now added if no "Start trace" actions are present.
- Warnings for "Start trace" actions were not handled properly if both types of action were enabled at the same time. They are now handled correctly.

Signed-off-by: Paul Cheeseman <paul.cheeseman@uk.ibm.com>