### PR TITLE
Fix date and link for OpenJDK 14

### DIFF
--- a/oj9_whatsnew.html
+++ b/oj9_whatsnew.html
@@ -97,13 +97,13 @@ The project website pages cannot be redistributed
       <div class="f-section-item" id="openj90200">
       <div class="f-content-container">
       <h3>Eclipse OpenJ9 version 0.20.0 released</h3>
-      <p><i>14 April 2020</i>
+      <p><i>17 April 2020</i>
       </p>
       <p>OpenJ9 version 0.20.0 supports OpenJDK version 8, 11, and 14. OpenJDK builds that contain version 0.20.0 are now available from the AdoptOpenJDK community project:
       </p>
       <p align=center><a href="https://adoptopenjdk.net/releases.html?variant=openjdk8&jvmVariant=openj9" target="_blank">OpenJDK version 8 <i class="fa fa-external-link" aria-hidden="true" style="color: #407471;opacity: 0.7; font-size:.9rem"></i></a>
       <br/><a href="https://adoptopenjdk.net/releases.html?variant=openjdk11&jvmVariant=openj9" target="_blank">OpenJDK version 11 <i class="fa fa-external-link" aria-hidden="true" style="color: #407471;opacity: 0.7; font-size:.9rem"></i></a>
-      <br/><a href="https://adoptopenjdk.net/releases.html?variant=openjdk13&jvmVariant=openj9" target="_blank">OpenJDK version 13 <i class="fa fa-external-link" aria-hidden="true" style="color: #407471;opacity: 0.7; font-size:.9rem"></i></a>
+      <br/><a href="https://adoptopenjdk.net/releases.html?variant=openjdk14&jvmVariant=openj9" target="_blank">OpenJDK version 14 <i class="fa fa-external-link" aria-hidden="true" style="color: #407471;opacity: 0.7; font-size:.9rem"></i></a>
       </p>
 
       <p>In addition to the usual Linux distributions available, we're pleased to introduce an early access release of OpenJDK 11 for the 64-bit ARM


### PR DESCRIPTION
Update release date.
Also fix bad link to OpenJDK14 binary at Adopt.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>