### PR TITLE
Fix JDK14 build instructions

### DIFF
--- a/oj9_build.html
+++ b/oj9_build.html
@@ -211,7 +211,7 @@ The project website pages cannot be redistributed
           </ul>
           <p>where <code>&lt;platform&gt;</code> reflects the Dockerfile you chose.
           </p>
-          <p>For example, the <strong>Linux 64-bit (x86-64)</strong> Dockerfile directory is: <code>linux-x86_64-normal-server-release</code>
+          <p>For example, the <strong>Linux 64-bit (x86-64)</strong> Dockerfile directory is: <code>linux-x86_64-server-release</code>
           </p>
 
         </div>
@@ -344,7 +344,7 @@ OpenJDK  - 27f5b8f based on jdk8u152-b03)
           </p>
           <p>where <code>&lt;platform&gt;</code> reflects the Dockerfile you chose.
           </p>
-          <p>For example, the <strong>Linux 64-bit (x86-64)</strong> Dockerfile directory is: <code>linux-x86_64-normal-server-release</code>
+          <p>For example, the <strong>Linux 64-bit (x86-64)</strong> Dockerfile directory is: <code>linux-x86_64-server-release</code>
           </p>
 
         </div>
@@ -477,7 +477,7 @@ JCL      - 98f2038 based on jdk-11+28)
           </p>
           <p>where <code>&lt;platform&gt;</code> reflects the Dockerfile you chose.
           </p>
-          <p>For example, the <strong>Linux 64-bit (x86-64)</strong> Dockerfile directory is: <code>linux-x86_64-normal-server-release</code>
+          <p>For example, the <strong>Linux 64-bit (x86-64)</strong> Dockerfile directory is: <code>linux-x86_64-server-release</code>
           </p>
 
         </div>


### PR DESCRIPTION
Removed '-normal' from dockerfile directory, given that JDK14 and later creates build directory like 'linux-x86_64-server-release'

Closes #246
Signed-off-by: Beatriz Rezener <beatrizrezener@gmail.com>