### PR TITLE
Add the css for option builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "gatsby build",
     "develop": "gatsby develop",
-    "deploy": "gatsby clean && gatsby build --prefix-paths && mkdir public/tools && cp tools/* public/tools && gh-pages -b $BRANCH -r $REPO -d public",
+    "deploy": "gatsby clean && gatsby build --prefix-paths && gh-pages -b $BRANCH -r $REPO -d public",
     "format": "prettier --write src/**/*.{js,jsx}",
     "start": "npm run develop",
     "serve": "gatsby serve",

--- a/static/tools/oj9_option_builder.css
+++ b/static/tools/oj9_option_builder.css
@@ -1,0 +1,106 @@
+/*
+Copyright (c) 2017, 2019 IBM Corp. and others
+This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution and is available at http://eclipse.org/legal/epl-2.0 or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0. 
+This Source Code may also be made available under the following Secondary Licenses when the conditions for such availability set forth in the Eclipse Public License, v. 2.0 are satisfied: GNU General Public License, version 2 with the GNU Classpath Exception [1] and GNU General Public License, version 2 with the OpenJDK Assembly Exception [2]. 
+[1] https://www.gnu.org/software/classpath/license.html  
+[2] http://openjdk.java.net/legal/assembly-exception.html 
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ The project website pages cannot be redistributed 
+ */
+
+ body {
+    font-family: verdana;
+    font-size: 10pt;
+}
+
+table {
+    font-size: 10pt;
+}
+
+button {
+    font-size: 10pt;
+	padding: 2px;
+}
+
+button.add {
+    width: 110px;
+}
+
+label {
+    vertical-align: middle;
+}
+
+input {
+    vertical-align: middle;
+}
+
+input[type=text] {
+    padding: 2px 2px;
+	box-sizing: border-box;
+}
+
+input[type=number] {
+    padding: 2px 2px;
+    box-sizing: border-box;
+	width: 70px;
+}
+
+select {
+    padding: 2px 2px;
+    box-sizing: border-box;
+	vertical-align: middle;
+}
+
+label[data-disabled=true] {
+    color: #ccc;
+}
+
+label[data-disabled=false] {
+    color: #000;
+}
+
+td {
+    vertical-align: middle;
+	height: 20px">
+}
+
+ul {
+    list-style-type: none;
+	min-height: 85px;
+	padding-left: 5px;
+	padding-top: 0px;
+	margin-top: 0px;
+}
+
+li {
+    padding: 2px 0px;	
+}
+
+a.remove {
+    vertical-align: middle;
+	font-size: 12pt;
+    text-decoration: none;
+	color: red;
+}
+
+td.head1 {
+  font-size:16pt;
+  color:white;
+  background:#888888;
+  text-align:center;
+  text-align:left;
+  padding:.3rem 0 .3rem 1rem;
+  font-weight:bold;
+}
+td.head2 {
+  padding: 1rem 0 1rem 0;
+  text-align:right;
+}
+
+a {
+  text-decoration: none;
+	color: #af6e3d;
+}
+a:hover {
+  color: #da7a08;
+}

--- a/static/tools/xdump_option_builder.html
+++ b/static/tools/xdump_option_builder.html
@@ -1248,7 +1248,7 @@ ul {
 
 </style>
 
-<link rel="stylesheet" type="text/css" href="../css/oj9_option_builder.css">
+<link rel="stylesheet" type="text/css" href="oj9_option_builder.css">
 
 </head>
 

--- a/static/tools/xtrace_option_builder.html
+++ b/static/tools/xtrace_option_builder.html
@@ -2666,7 +2666,7 @@ a.remove {
 
 </style>
 
-<link rel="stylesheet" type="text/css" href="../css/oj9_option_builder.css">
+<link rel="stylesheet" type="text/css" href="oj9_option_builder.css">
 
 <!--
 Copyright (c) 2017, 2020 IBM Corp. and others


### PR DESCRIPTION
The option builder html files refer to an external css file which was deleted. Added the file back in and moved all option builder the html and ccs  into a self contained /static/tools/ directory.